### PR TITLE
fix: improve DefaultCellCollector sync check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ default = []
 test = []
 
 [dev-dependencies]
+ckb-vm-definitions = "=0.21.3"
 clap = { version = "3.1.9", features = ["derive"] }
 httpmock = "0.6"
 async-global-executor = "=2.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-sdk"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Linfeng Qian <thewawar@gmail.com>", "Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"

--- a/src/tx_builder/mod.rs
+++ b/src/tx_builder/mod.rs
@@ -388,6 +388,7 @@ pub fn balance_tx_capacity(
     }
     let mut lock_script_idx = 0;
     let mut cell_deps = Vec::new();
+    #[allow(clippy::mutable_key_type)]
     let mut resolved_scripts = HashSet::new();
     let mut inputs = Vec::new();
     let mut change_output: Option<CellOutput> = None;

--- a/src/tx_builder/omni_lock.rs
+++ b/src/tx_builder/omni_lock.rs
@@ -45,6 +45,7 @@ impl TxBuilder for OmniLockTransferBuilder {
     ) -> Result<TransactionView, TxBuilderError> {
         #[allow(clippy::mutable_key_type)]
         let mut cell_deps = HashSet::new();
+        #[allow(clippy::mutable_key_type)]
         let mut inputs = HashSet::new();
         let mut outputs = Vec::new();
         let mut outputs_data = Vec::new();


### PR DESCRIPTION
Since ckb-indexer's [poll interval is 2.0s](https://github.com/nervosnetwork/ckb-indexer/blob/0a6f6f9ec29256662bdb903740996dedb4cbc329/src/main.rs#L62), so we need increase the retry times.