### PR TITLE
refactor: use anyhow::Error to replace Box<dyn std::error::Error>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.30"
+anyhow = "1.0.63"
 bech32 = "0.8.1"
 log = "0.4.6"
 reqwest = { version = "0.11", features = ["json", "blocking"] }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 
+use anyhow::anyhow;
 use ckb_jsonrpc_types::Serialize;
 use rand::{thread_rng, Rng};
 use thiserror::Error;
@@ -335,9 +336,9 @@ impl TransactionDependencyProvider for Context {
         &self,
         _tx_hash: &Byte32,
     ) -> Result<TransactionView, TransactionDependencyError> {
-        Err(TransactionDependencyError::Other(
-            "context get_transaction".to_string().into(),
-        ))
+        Err(TransactionDependencyError::Other(anyhow!(
+            "context get_transaction"
+        )))
     }
     // For get the output information of inputs or cell_deps, those cell should be live cell
     fn get_cell(&self, out_point: &OutPoint) -> Result<CellOutput, TransactionDependencyError> {
@@ -360,10 +361,7 @@ impl TransactionDependencyProvider for Context {
 }
 
 impl HeaderDepResolver for Context {
-    fn resolve_by_tx(
-        &self,
-        tx_hash: &Byte32,
-    ) -> Result<Option<HeaderView>, Box<dyn std::error::Error>> {
+    fn resolve_by_tx(&self, tx_hash: &Byte32) -> Result<Option<HeaderView>, anyhow::Error> {
         let mut header_opt = None;
         for item in &self.inputs {
             if item.input.previous_output().tx_hash() == *tx_hash {
@@ -386,10 +384,7 @@ impl HeaderDepResolver for Context {
         }
         Ok(None)
     }
-    fn resolve_by_number(
-        &self,
-        number: u64,
-    ) -> Result<Option<HeaderView>, Box<dyn std::error::Error>> {
+    fn resolve_by_number(&self, number: u64) -> Result<Option<HeaderView>, anyhow::Error> {
         for mock_header in &self.header_deps {
             if number == mock_header.number() {
                 return Ok(Some(mock_header.clone()));

--- a/src/traits/dummy_impls.rs
+++ b/src/traits/dummy_impls.rs
@@ -8,6 +8,7 @@ use crate::traits::{
     CellCollector, CellCollectorError, CellQueryOptions, HeaderDepResolver, LiveCell,
     TransactionDependencyError, TransactionDependencyProvider,
 };
+use anyhow::anyhow;
 
 /// A dummy CellCollector. All methods will return error if possible.
 #[derive(Default)]
@@ -19,21 +20,17 @@ impl CellCollector for DummyCellCollector {
         _query: &CellQueryOptions,
         _apply_changes: bool,
     ) -> Result<(Vec<LiveCell>, u64), CellCollectorError> {
-        Err(CellCollectorError::Other(
-            "dummy collect_live_cells".to_string().into(),
-        ))
+        Err(CellCollectorError::Other(anyhow!(
+            "dummy collect_live_cells"
+        )))
     }
 
     fn lock_cell(&mut self, _out_point: OutPoint) -> Result<(), CellCollectorError> {
-        Err(CellCollectorError::Other(
-            "dummy lock_cell".to_string().into(),
-        ))
+        Err(CellCollectorError::Other(anyhow!("dummy lock_cell")))
     }
 
     fn apply_tx(&mut self, _tx: Transaction) -> Result<(), CellCollectorError> {
-        Err(CellCollectorError::Other(
-            "dummy apply_tx".to_string().into(),
-        ))
+        Err(CellCollectorError::Other(anyhow!("dummy apply_tx")))
     }
     fn reset(&mut self) {}
 }
@@ -43,17 +40,11 @@ impl CellCollector for DummyCellCollector {
 pub struct DummyHeaderDepResolver;
 
 impl HeaderDepResolver for DummyHeaderDepResolver {
-    fn resolve_by_tx(
-        &self,
-        _tx_hash: &Byte32,
-    ) -> Result<Option<HeaderView>, Box<dyn std::error::Error>> {
-        Err("dummy resolve_by_tx".to_string().into())
+    fn resolve_by_tx(&self, _tx_hash: &Byte32) -> Result<Option<HeaderView>, anyhow::Error> {
+        Err(anyhow!("dummy resolve_by_tx"))
     }
-    fn resolve_by_number(
-        &self,
-        _number: u64,
-    ) -> Result<Option<HeaderView>, Box<dyn std::error::Error>> {
-        Err("dummy resolve_by_number".to_string().into())
+    fn resolve_by_number(&self, _number: u64) -> Result<Option<HeaderView>, anyhow::Error> {
+        Err(anyhow!("dummy resolve_by_number"))
     }
 }
 
@@ -67,26 +58,24 @@ impl TransactionDependencyProvider for DummyTransactionDependencyProvider {
         &self,
         _tx_hash: &Byte32,
     ) -> Result<TransactionView, TransactionDependencyError> {
-        Err(TransactionDependencyError::Other(
-            "dummy get_transaction".to_string().into(),
-        ))
+        Err(TransactionDependencyError::Other(anyhow!(
+            "dummy get_transaction"
+        )))
     }
     // For get the output information of inputs or cell_deps, those cell should be live cell
     fn get_cell(&self, _out_point: &OutPoint) -> Result<CellOutput, TransactionDependencyError> {
-        Err(TransactionDependencyError::Other(
-            "dummy get_cell".to_string().into(),
-        ))
+        Err(TransactionDependencyError::Other(anyhow!("dummy get_cell")))
     }
     // For get the output data information of inputs or cell_deps
     fn get_cell_data(&self, _out_point: &OutPoint) -> Result<Bytes, TransactionDependencyError> {
-        Err(TransactionDependencyError::Other(
-            "dummy get_cell_data".to_string().into(),
-        ))
+        Err(TransactionDependencyError::Other(anyhow!(
+            "dummy get_cell_data"
+        )))
     }
     // For get the header information of header_deps
     fn get_header(&self, _block_hash: &Byte32) -> Result<HeaderView, TransactionDependencyError> {
-        Err(TransactionDependencyError::Other(
-            "dummy get_header".to_string().into(),
-        ))
+        Err(TransactionDependencyError::Other(anyhow!(
+            "dummy get_header"
+        )))
     }
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -44,8 +44,8 @@ pub enum SignerError {
     InvalidTransaction(String),
 
     // maybe hardware wallet error or io error
-    #[error("other error: `{0}`")]
-    Other(#[from] Box<dyn std::error::Error>),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 /// A signer abstraction, support signer type:
@@ -76,8 +76,8 @@ pub enum TransactionDependencyError {
     #[error("the resource is not found in the provider: `{0}`")]
     NotFound(String),
 
-    #[error("other error: `{0}`")]
-    Other(#[from] Box<dyn std::error::Error>),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 /// Provider dependency information of a transaction:
@@ -158,11 +158,11 @@ impl CellProvider for &dyn TransactionDependencyProvider {
 /// Cell collector errors
 #[derive(Error, Debug)]
 pub enum CellCollectorError {
-    #[error("internal error: `{0}`")]
-    Internal(Box<dyn std::error::Error>),
+    #[error(transparent)]
+    Internal(anyhow::Error),
 
-    #[error("other error: `{0}`")]
-    Other(Box<dyn std::error::Error>),
+    #[error(transparent)]
+    Other(anyhow::Error),
 }
 
 #[derive(Debug, Clone)]
@@ -366,14 +366,8 @@ pub trait CellDepResolver {
 }
 pub trait HeaderDepResolver {
     /// Resolve header dep by trancation hash
-    fn resolve_by_tx(
-        &self,
-        tx_hash: &Byte32,
-    ) -> Result<Option<HeaderView>, Box<dyn std::error::Error>>;
+    fn resolve_by_tx(&self, tx_hash: &Byte32) -> Result<Option<HeaderView>, anyhow::Error>;
 
     /// Resolve header dep by block number
-    fn resolve_by_number(
-        &self,
-        number: u64,
-    ) -> Result<Option<HeaderView>, Box<dyn std::error::Error>>;
+    fn resolve_by_number(&self, number: u64) -> Result<Option<HeaderView>, anyhow::Error>;
 }

--- a/src/tx_builder/acp.rs
+++ b/src/tx_builder/acp.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use anyhow::anyhow;
 use ckb_types::{
     core::{TransactionBuilder, TransactionView},
     packed::{CellInput, Script},
@@ -53,13 +54,10 @@ impl TxBuilder for AcpTransferBuilder {
             let query = CellQueryOptions::new_lock(receiver.lock_script.clone());
             let (cells, input_capacity) = cell_collector.collect_live_cells(&query, true)?;
             if cells.is_empty() {
-                return Err(TxBuilderError::Other(
-                    format!(
-                        "can not found cell by lock script: {:?}",
-                        receiver.lock_script
-                    )
-                    .into(),
-                ));
+                return Err(TxBuilderError::Other(anyhow!(
+                    "can not found cell by lock script: {:?}",
+                    receiver.lock_script
+                )));
             }
             let input_cell = &cells[0];
             let input = CellInput::new(input_cell.out_point.clone(), 0);

--- a/src/tx_builder/dao.rs
+++ b/src/tx_builder/dao.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use anyhow::anyhow;
 use ckb_types::{
     bytes::Bytes,
     core::{Capacity, FeeRate, ScriptHashType, TransactionBuilder, TransactionView},
@@ -52,9 +53,9 @@ impl TxBuilder for DaoDepositBuilder {
         _tx_dep_provider: &dyn TransactionDependencyProvider,
     ) -> Result<TransactionView, TxBuilderError> {
         if self.receivers.is_empty() {
-            return Err(TxBuilderError::InvalidParameter(
-                "empty dao receivers".to_string().into(),
-            ));
+            return Err(TxBuilderError::InvalidParameter(anyhow!(
+                "empty dao receivers"
+            )));
         }
         let dao_type_script = Script::new_builder()
             .code_hash(DAO_TYPE_HASH.pack())
@@ -128,9 +129,9 @@ impl TxBuilder for DaoPrepareBuilder {
         tx_dep_provider: &dyn TransactionDependencyProvider,
     ) -> Result<TransactionView, TxBuilderError> {
         if self.items.is_empty() {
-            return Err(TxBuilderError::InvalidParameter(
-                "No cell to prepare".to_string().into(),
-            ));
+            return Err(TxBuilderError::InvalidParameter(anyhow!(
+                "No cell to prepare"
+            )));
         }
 
         let dao_type_script = Script::new_builder()
@@ -157,9 +158,9 @@ impl TxBuilder for DaoPrepareBuilder {
                 .ok_or_else(|| TxBuilderError::ResolveHeaderDepByTxHashFailed(tx_hash.clone()))?;
             let input_cell = tx_dep_provider.get_cell(&out_point)?;
             if input_cell.type_().to_opt().as_ref() != Some(&dao_type_script) {
-                return Err(TxBuilderError::InvalidParameter(
-                    "the input cell has invalid type script".to_string().into(),
-                ));
+                return Err(TxBuilderError::InvalidParameter(anyhow!(
+                    "the input cell has invalid type script"
+                )));
             }
             let input_lock_cell_dep = cell_dep_resolver
                 .resolve(&input_cell.lock())
@@ -247,9 +248,9 @@ impl TxBuilder for DaoWithdrawBuilder {
         tx_dep_provider: &dyn TransactionDependencyProvider,
     ) -> Result<TransactionView, TxBuilderError> {
         if self.items.is_empty() {
-            return Err(TxBuilderError::InvalidParameter(
-                "No cell to withdraw".to_string().into(),
-            ));
+            return Err(TxBuilderError::InvalidParameter(anyhow!(
+                "No cell to withdraw"
+            )));
         }
 
         let dao_type_script = Script::new_builder()
@@ -281,22 +282,19 @@ impl TxBuilder for DaoWithdrawBuilder {
             prepare_block_hashes.push(prepare_header.hash());
             let input_cell = tx_dep_provider.get_cell(out_point)?;
             if input_cell.type_().to_opt().as_ref() != Some(&dao_type_script) {
-                return Err(TxBuilderError::InvalidParameter(
-                    "the input cell has invalid type script".to_string().into(),
-                ));
+                return Err(TxBuilderError::InvalidParameter(anyhow!(
+                    "the input cell has invalid type script"
+                )));
             }
             let input_lock_cell_dep = cell_dep_resolver
                 .resolve(&input_cell.lock())
                 .ok_or_else(|| TxBuilderError::ResolveCellDepFailed(input_cell.lock()))?;
             let data = tx_dep_provider.get_cell_data(out_point)?;
             if data.len() != 8 {
-                return Err(TxBuilderError::InvalidParameter(
-                    format!(
-                        "the input cell has invalid data length, expected: 8, got: {}",
-                        data.len()
-                    )
-                    .into(),
-                ));
+                return Err(TxBuilderError::InvalidParameter(anyhow!(
+                    "the input cell has invalid data length, expected: 8, got: {}",
+                    data.len()
+                )));
             }
             let deposit_number = {
                 let mut number_bytes = [0u8; 8];
@@ -392,14 +390,11 @@ impl TxBuilder for DaoWithdrawBuilder {
                 outputs_data,
             } => {
                 if outputs.len() != outputs_data.len() {
-                    return Err(TxBuilderError::InvalidParameter(
-                        format!(
-                            "receiver outputs length ({}) not match with outputs data length ({})",
-                            outputs.len(),
-                            outputs_data.len(),
-                        )
-                        .into(),
-                    ));
+                    return Err(TxBuilderError::InvalidParameter(anyhow!(
+                        "receiver outputs length ({}) not match with outputs data length ({})",
+                        outputs.len(),
+                        outputs_data.len(),
+                    )));
                 }
                 (
                     outputs.clone(),

--- a/src/unlock/omni_lock.rs
+++ b/src/unlock/omni_lock.rs
@@ -374,8 +374,8 @@ pub enum ConfigError {
     #[error("there is no multisig config in the OmniLockConfig")]
     NoMultiSigConfig,
 
-    #[error("other error: `{0}`")]
-    Other(#[from] Box<dyn std::error::Error>),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Hash, Eq, PartialEq, Default)]


### PR DESCRIPTION
### What problem does this PR solve?
Use use anyhow::Error to replace Box &lt;  dyn std::error::Error &gt;
So in a app can use anyhow! directly.