### PR TITLE
refactor: 💡 use hash instead pubkey directly

### DIFF
--- a/examples/transfer_from_omnilock.rs
+++ b/examples/transfer_from_omnilock.rs
@@ -13,6 +13,7 @@ use ckb_sdk::{
     types::NetworkType,
     unlock::{OmniLockConfig, OmniLockScriptSigner},
     unlock::{OmniLockUnlocker, OmniUnlockMode, ScriptUnlocker},
+    util::blake160,
     Address, HumanCapacity, ScriptGroup, ScriptId, SECP256K1,
 };
 use ckb_types::{
@@ -230,7 +231,7 @@ fn build_omnilock_addr(args: &BuildOmniLockAddrArgs) -> Result<(), Box<dyn StdEr
     let cell =
         build_omnilock_cell_dep(&mut ckb_client, &args.omnilock_tx_hash, args.omnilock_index)?;
     let arg = H160::from_slice(&args.receiver.payload().args()).unwrap();
-    let config = OmniLockConfig::new_pubkey_hash_with_lockarg(arg);
+    let config = OmniLockConfig::new_pubkey_hash(arg);
     let address_payload = {
         let args = config.build_args();
         ckb_sdk::AddressPayload::new_full(ScriptHashType::Type, cell.type_hash.pack(), args)
@@ -265,7 +266,9 @@ fn build_transfer_tx(
     let mut ckb_client = CkbRpcClient::new(args.ckb_rpc.as_str());
     let cell =
         build_omnilock_cell_dep(&mut ckb_client, &args.omnilock_tx_hash, args.omnilock_index)?;
-    let omnilock_config = OmniLockConfig::new_pubkey_hash(&pubkey.into());
+
+    let pubkey_hash = blake160(&pubkey.serialize());
+    let omnilock_config = OmniLockConfig::new_pubkey_hash(pubkey_hash);
     // Build CapacityBalancer
     let sender = Script::new_builder()
         .code_hash(cell.type_hash.pack())

--- a/examples/transfer_from_omnilock_ethereum.rs
+++ b/examples/transfer_from_omnilock_ethereum.rs
@@ -236,7 +236,8 @@ fn build_omnilock_addr(args: &BuildOmniLockAddrArgs) -> Result<(), Box<dyn StdEr
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &privkey);
     println!("pubkey:{:?}", hex_string(&pubkey.serialize()));
     println!("pubkey:{:?}", hex_string(&pubkey.serialize_uncompressed()));
-    let config = OmniLockConfig::new_ethereum(&pubkey.into());
+    let addr = keccak160(Pubkey::from(pubkey).as_ref());
+    let config = OmniLockConfig::new_ethereum(addr);
     let address_payload = {
         let args = config.build_args();
         ckb_sdk::AddressPayload::new_full(ScriptHashType::Type, cell.type_hash.pack(), args)
@@ -273,7 +274,8 @@ fn build_transfer_tx(
     let mut ckb_client = CkbRpcClient::new(args.ckb_rpc.as_str());
     let cell =
         build_omnilock_cell_dep(&mut ckb_client, &args.omnilock_tx_hash, args.omnilock_index)?;
-    let omnilock_config = OmniLockConfig::new_ethereum(&pubkey.into());
+    let addr = keccak160(Pubkey::from(pubkey).as_ref());
+    let omnilock_config = OmniLockConfig::new_ethereum(addr);
     // Build CapacityBalancer
     let sender = Script::new_builder()
         .code_hash(cell.type_hash.pack())

--- a/src/tests/omni_lock.rs
+++ b/src/tests/omni_lock.rs
@@ -23,7 +23,7 @@ use crate::{
         OmniLockScriptSigner, OmniLockUnlocker, OmniUnlockMode, ScriptUnlocker,
         SecpSighashUnlocker,
     },
-    util::blake160,
+    util::{blake160, keccak160},
     ScriptId, Since,
 };
 
@@ -80,7 +80,7 @@ fn test_omnilock_transfer_from_sighash() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sender_key);
-    let cfg = OmniLockConfig::new_pubkey_hash(&pubkey.into());
+    let cfg = OmniLockConfig::new_pubkey_hash(blake160(&pubkey.serialize()));
     test_omnilock_simple_hash(cfg);
 }
 
@@ -88,7 +88,7 @@ fn test_omnilock_transfer_from_sighash() {
 fn test_omnilock_transfer_from_ethereum() {
     let account0_key = secp256k1::SecretKey::from_slice(ACCOUNT0_KEY.as_bytes()).unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account0_key);
-    let cfg = OmniLockConfig::new_ethereum(&Pubkey::from(pubkey));
+    let cfg = OmniLockConfig::new_ethereum(keccak160(Pubkey::from(pubkey).as_ref()));
     test_omnilock_simple_hash(cfg);
 }
 
@@ -154,14 +154,13 @@ fn test_omnilock_transfer_from_sighash_wl() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sender_key);
-    let pubkey_hash = blake160(&pubkey.serialize());
-    let mut cfg = OmniLockConfig::new_pubkey_hash_with_lockarg(pubkey_hash);
+    let mut cfg = OmniLockConfig::new_pubkey_hash(blake160(&pubkey.serialize()));
 
     let account3_key = secp256k1::SecretKey::from_slice(ACCOUNT3_KEY.as_bytes())
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account3_key);
-    let id = Identity::new_pubkey_hash(&pubkey.into());
+    let id = Identity::new_pubkey_hash(blake160(&pubkey.serialize()));
     cfg.set_admin_config(AdminConfig::new(
         H256::default(),
         SmtProofEntryVec::default(),
@@ -179,13 +178,13 @@ fn test_omnilock_transfer_from_sighash_wl_input_admin() {
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sender_key);
     let pubkey_hash = blake160(&pubkey.serialize());
-    let mut cfg = OmniLockConfig::new_pubkey_hash_with_lockarg(pubkey_hash);
+    let mut cfg = OmniLockConfig::new_pubkey_hash(pubkey_hash);
 
     let account3_key = secp256k1::SecretKey::from_slice(ACCOUNT3_KEY.as_bytes())
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account3_key);
-    let id = Identity::new_pubkey_hash(&pubkey.into());
+    let id = Identity::new_pubkey_hash(blake160(&pubkey.serialize()));
     cfg.set_admin_config(AdminConfig::new(
         H256::default(),
         SmtProofEntryVec::default(),
@@ -295,13 +294,13 @@ fn test_omnilock_transfer_from_ethereum_wl_input_admin() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account0_key);
-    let mut cfg = OmniLockConfig::new_ethereum(&Pubkey::from(pubkey));
+    let mut cfg = OmniLockConfig::new_ethereum(keccak160(Pubkey::from(pubkey).as_ref()));
 
     let account3_key = secp256k1::SecretKey::from_slice(ACCOUNT3_KEY.as_bytes())
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account3_key);
-    let id = Identity::new_ethereum(&pubkey.into());
+    let id = Identity::new_ethereum(keccak160(Pubkey::from(pubkey).as_ref()));
     cfg.set_admin_config(AdminConfig::new(
         H256::default(),
         SmtProofEntryVec::default(),
@@ -318,13 +317,13 @@ fn test_omnilock_transfer_from_ethereum_wl() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account0_key);
-    let mut cfg = OmniLockConfig::new_ethereum(&Pubkey::from(pubkey));
+    let mut cfg = OmniLockConfig::new_ethereum(keccak160(Pubkey::from(pubkey).as_ref()));
 
     let account3_key = secp256k1::SecretKey::from_slice(ACCOUNT3_KEY.as_bytes())
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account3_key);
-    let id = Identity::new_ethereum(&pubkey.into());
+    let id = Identity::new_ethereum(keccak160(Pubkey::from(pubkey).as_ref()));
     cfg.set_admin_config(AdminConfig::new(
         H256::default(),
         SmtProofEntryVec::default(),
@@ -342,13 +341,13 @@ fn test_omnilock_transfer_from_sighash_wl_admin() {
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sender_key);
     let pubkey_hash = blake160(&pubkey.serialize());
-    let mut cfg = OmniLockConfig::new_pubkey_hash_with_lockarg(pubkey_hash);
+    let mut cfg = OmniLockConfig::new_pubkey_hash(pubkey_hash);
 
     let account3_key = secp256k1::SecretKey::from_slice(ACCOUNT3_KEY.as_bytes())
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account3_key);
-    let id = Identity::new_pubkey_hash(&pubkey.into());
+    let id = Identity::new_pubkey_hash(blake160(&pubkey.serialize()));
     cfg.set_admin_config(AdminConfig::new(
         H256::default(),
         SmtProofEntryVec::default(),
@@ -366,13 +365,13 @@ fn test_omnilock_transfer_from_ethereum_wl_admin() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account0_key);
-    let mut cfg = OmniLockConfig::new_ethereum(&Pubkey::from(pubkey));
+    let mut cfg = OmniLockConfig::new_ethereum(keccak160(Pubkey::from(pubkey).as_ref()));
 
     let account3_key = secp256k1::SecretKey::from_slice(ACCOUNT3_KEY.as_bytes())
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account3_key);
-    let id = Identity::new_ethereum(&pubkey.into());
+    let id = Identity::new_ethereum(keccak160(Pubkey::from(pubkey).as_ref()));
     cfg.set_admin_config(AdminConfig::new(
         H256::default(),
         SmtProofEntryVec::default(),
@@ -485,7 +484,7 @@ fn test_omnilock_transfer_from_sighash2_wl() {
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sender_key);
     let pubkey_hash = blake160(&pubkey.serialize());
-    let cfg = OmniLockConfig::new_pubkey_hash_with_lockarg(pubkey_hash);
+    let cfg = OmniLockConfig::new_pubkey_hash(pubkey_hash);
     test_omnilock_simple_hash_rc2(cfg);
 }
 
@@ -974,7 +973,10 @@ fn test_omnilock_transfer_from_acp() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sender_key);
-    let mut cfg = OmniLockConfig::new_pubkey_hash(&pubkey.into());
+
+    let pubkey_hash = blake160(&pubkey.serialize());
+    let mut cfg = OmniLockConfig::new_pubkey_hash(pubkey_hash);
+
     cfg.set_acp_config(OmniLockAcpConfig::new(0, 0));
     let unlock_mode = OmniUnlockMode::Normal;
     let sender = build_omnilock_script(&cfg);
@@ -1044,7 +1046,9 @@ fn test_omnilock_transfer_to_acp() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &receiver_key);
-    let mut cfg = OmniLockConfig::new_pubkey_hash(&pubkey.into());
+
+    let pubkey_hash = blake160(&pubkey.serialize());
+    let mut cfg = OmniLockConfig::new_pubkey_hash(pubkey_hash);
     cfg.set_acp_config(OmniLockAcpConfig::new(9, 5));
     let unlock_mode = OmniUnlockMode::Normal;
     let receiver = build_omnilock_script(&cfg);
@@ -1110,7 +1114,7 @@ fn build_omnilock_acp_cfg(account_key: &H256) -> OmniLockConfig {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &receiver_key);
-    let mut cfg = OmniLockConfig::new_pubkey_hash(&pubkey.into());
+    let mut cfg = OmniLockConfig::new_pubkey_hash(blake160(&pubkey.serialize()));
     cfg.set_acp_config(OmniLockAcpConfig::new(9, 2));
     cfg
 }
@@ -1227,7 +1231,8 @@ fn test_omnilock_transfer_from_sighash_timelock() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sender_key);
-    let cfg = OmniLockConfig::new_pubkey_hash(&pubkey.into());
+    let pubkey_hash = blake160(&pubkey.serialize());
+    let cfg = OmniLockConfig::new_pubkey_hash(pubkey_hash);
     test_omnilock_simple_hash_timelock(cfg);
 }
 
@@ -1235,7 +1240,7 @@ fn test_omnilock_transfer_from_sighash_timelock() {
 fn test_omnilock_transfer_from_ethereum_timelock() {
     let account0_key = secp256k1::SecretKey::from_slice(ACCOUNT0_KEY.as_bytes()).unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &account0_key);
-    let cfg = OmniLockConfig::new_ethereum(&Pubkey::from(pubkey));
+    let cfg = OmniLockConfig::new_ethereum(keccak160(Pubkey::from(pubkey).as_ref()));
     test_omnilock_simple_hash_timelock(cfg);
 }
 
@@ -1342,7 +1347,8 @@ fn test_omnilock_sudt_supply() {
         .map_err(|err| format!("invalid sender secret key: {}", err))
         .unwrap();
     let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &sender_key);
-    let mut cfg = OmniLockConfig::new_pubkey_hash(&pubkey.into());
+    let pubkey_hash = blake160(&pubkey.serialize());
+    let mut cfg = OmniLockConfig::new_pubkey_hash(pubkey_hash);
     let (info_cell_type_script, type_script_hash) = build_info_cell_type_script();
     cfg.set_info_cell(type_script_hash);
 

--- a/src/unlock/omni_lock.rs
+++ b/src/unlock/omni_lock.rs
@@ -7,7 +7,6 @@ use crate::{
         omni_lock::{Auth, Identity as IdentityType, IdentityOpt, OmniLockWitnessLock},
         xudt_rce_mol::SmtProofEntryVec,
     },
-    util::{blake160, keccak160},
 };
 use ckb_types::{
     bytes::{BufMut, Bytes, BytesMut},
@@ -16,7 +15,6 @@ use ckb_types::{
     H160, H256,
 };
 
-use ckb_crypto::secp::Pubkey;
 pub use ckb_types::prelude::Pack;
 use enum_repr_derive::{FromEnumToRepr, TryFromReprToEnum};
 use serde::{de::Unexpected, Deserialize, Serialize};
@@ -91,8 +89,9 @@ impl Identity {
     }
 
     /// Create a pubkey hash algorithm Identity
-    pub fn new_pubkey_hash(pubkey: &Pubkey) -> Self {
-        let pubkey_hash = blake160(&pubkey.serialize());
+    /// # Arguments
+    /// * `pubkey_hash` blake160 hash of a public key.
+    pub fn new_pubkey_hash(pubkey_hash: H160) -> Self {
         Self::new(IdentityFlag::PubkeyHash, pubkey_hash)
     }
 
@@ -102,8 +101,9 @@ impl Identity {
         Identity::new(IdentityFlag::Multisig, blake160)
     }
     /// Create an ethereum Identity omnilock with pubkey
-    pub fn new_ethereum(pubkey: &Pubkey) -> Self {
-        let pubkey_hash = keccak160(pubkey.as_ref());
+    /// # Arguments
+    /// * `pubkey_hash` keccak160 hash of public key
+    pub fn new_ethereum(pubkey_hash: H160) -> Self {
         Self::new(IdentityFlag::Ethereum, pubkey_hash)
     }
 
@@ -424,15 +424,9 @@ pub struct OmniLockConfig {
 impl OmniLockConfig {
     /// Create a pubkey hash algorithm omnilock with proper argument
     /// # Arguments
-    /// * `lock_arg` proper 20 bytes auth content
-    pub fn new_pubkey_hash_with_lockarg(lock_arg: H160) -> Self {
+    /// * `lock_arg` blake160 hash of a public key.
+    pub fn new_pubkey_hash(lock_arg: H160) -> Self {
         Self::new(IdentityFlag::PubkeyHash, lock_arg)
-    }
-
-    /// Create a pubkey hash algorithm omnilock with pubkey
-    pub fn new_pubkey_hash(pubkey: &Pubkey) -> Self {
-        let pubkey_hash = blake160(&pubkey.serialize());
-        Self::new(IdentityFlag::PubkeyHash, pubkey_hash)
     }
 
     pub fn new_multisig(multisig_config: MultisigConfig) -> Self {
@@ -451,8 +445,22 @@ impl OmniLockConfig {
         }
     }
     /// Create an ethereum algorithm omnilock with pubkey
-    pub fn new_ethereum(pubkey: &Pubkey) -> Self {
-        let pubkey_hash = keccak160(pubkey.as_ref());
+    ///
+    /// # Arguments
+    ///
+    /// * `pubkey_hash` - a ehtereum address of an account.
+    ///
+    /// ```
+    /// // pubkey is a public ethereum address
+    /// use ckb_sdk::unlock::OmniLockConfig;
+    /// use ckb_sdk::util::keccak160;
+    /// use ckb_crypto::secp::Pubkey;
+    ///
+    /// let pubkey = Pubkey::from([0u8; 64]);
+    /// let pubkey_hash = keccak160(pubkey.as_ref());
+    /// let config = OmniLockConfig::new_ethereum(pubkey_hash);
+    /// ```
+    pub fn new_ethereum(pubkey_hash: H160) -> Self {
         Self::new(IdentityFlag::Ethereum, pubkey_hash)
     }
 


### PR DESCRIPTION
# What problems does this PR solve?

- Use the blake160 hash instead of public key directly for pubkey_hash omnilock;
- Use the keccak160 hash instead of public key directly for ethereum omnilock;