### PR TITLE
chore: 🤖 Bump to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.4.0
+* Update ckb to 0.106.0
+* Add `TxBuilder::build_balance_unlocked` to support transaction's cycles limitation.
+* chore: fix git repo url
 
 # 2.3.0
 * Update ckb to v0.105.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-sdk"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Linfeng Qian <thewawar@gmail.com>", "Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
### What does this PR do?
- Bump ckb-sdk-rust to version 2.4.0