### PR TITLE
chore: refactor SimpleTransactionBuilder

### DIFF
--- a/examples/send_ckb_example.rs
+++ b/examples/send_ckb_example.rs
@@ -12,22 +12,15 @@ use std::{error::Error as StdErr, str::FromStr};
 
 fn main() -> Result<(), Box<dyn StdErr>> {
     let network_info = NetworkInfo::testnet();
-    let sender = "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq2qf8keemy2p5uu0g0gn8cd4ju23s5269qk8rg4r";
-    let receiver="ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqv5dsed9par23x4g58seaw58j3ym5ml2hs8ztche";
-
     let configuration = TransactionBuilderConfiguration::new_with_network(network_info.clone())?;
-    // set small change action instead of default
-    // use ckb_sdk::transaction::SmallChangeAction;
-    // configuration.small_change_action = SmallChangeAction::AsFee { threshold: Capacity::bytes(61)?.as_u64() };
-    // configuration.small_change_action = SmallChangeAction::to_output(&sender.parse()?, Capacity::bytes(1)?.as_u64());
 
-    let addr = Address::from_str(sender)?;
-    let receiver = Address::from_str(receiver)?;
-    let iterator = InputIterator::new_with_address(&[addr], configuration.network_info());
+    let sender = Address::from_str("ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq2qf8keemy2p5uu0g0gn8cd4ju23s5269qk8rg4r")?;
+    let receiver=Address::from_str("ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqv5dsed9par23x4g58seaw58j3ym5ml2hs8ztche")?;
+
+    let iterator = InputIterator::new_with_address(&[sender], &network_info);
     let mut builder = SimpleTransactionBuilder::new(configuration, iterator);
-    let addr = Address::from_str(sender)?;
-    builder.add_output_from_addr(&receiver, Capacity::shannons(510_0000_0000u64));
-    builder.set_change_addr(&addr);
+    builder.add_output(&receiver, Capacity::shannons(510_0000_0000u64));
+
     let mut tx_with_groups = builder.build(&Default::default())?;
 
     let json_tx = ckb_jsonrpc_types::TransactionView::from(tx_with_groups.get_tx_view().clone());

--- a/examples/send_ckb_multisig_example.rs
+++ b/examples/send_ckb_multisig_example.rs
@@ -9,11 +9,13 @@ use ckb_sdk::{
     unlock::MultisigConfig,
     Address, CkbRpcClient, NetworkInfo,
 };
-use ckb_types::{core::Capacity, h160, h256, packed::Script};
+use ckb_types::{core::Capacity, h160, h256};
 use std::{error::Error as StdErr, str::FromStr};
 
 fn main() -> Result<(), Box<dyn StdErr>> {
     let network_info = NetworkInfo::testnet();
+    let configuration = TransactionBuilderConfiguration::new_with_network(network_info.clone())?;
+
     let multisig_config = MultisigConfig::new_with(
         vec![
             h160!("0x7336b0ba900684cb3cb00f0d46d4f64c0994a562"),
@@ -22,23 +24,13 @@ fn main() -> Result<(), Box<dyn StdErr>> {
         0,
         2,
     )?;
+    let sender = multisig_config.to_address(network_info.network_type, None);
+    let receiver = Address::from_str("ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq2qf8keemy2p5uu0g0gn8cd4ju23s5269qk8rg4r")?;
 
-    let configuration = TransactionBuilderConfiguration::new_with_network(network_info.clone())?;
-    // set small change action instead of default
-    // use ckb_sdk::transaction::SmallChangeAction;
-    // configuration.small_change_action = SmallChangeAction::AsFee { threshold: Capacity::bytes(61)?.as_u64() };
-    // configuration.small_change_action = SmallChangeAction::to_output(&sender.parse()?, Capacity::bytes(1)?.as_u64());
-
-    let sender_addr = multisig_config.to_address(network_info.network_type, None);
-
-    let iterator = InputIterator::new(
-        vec![Script::from(&multisig_config)],
-        configuration.network_info(),
-    );
+    let iterator = InputIterator::new_with_address(&[sender], &network_info);
     let mut builder = SimpleTransactionBuilder::new(configuration, iterator);
-    let addr = Address::from_str("ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq2qf8keemy2p5uu0g0gn8cd4ju23s5269qk8rg4r")?;
-    builder.add_output_from_addr(&addr, Capacity::shannons(501_0000_0000u64));
-    builder.set_change_addr(&sender_addr);
+    builder.add_output(&receiver, Capacity::shannons(510_0000_0000u64));
+
     let mut tx_with_groups =
         builder.build(&HandlerContexts::new_multisig(multisig_config.clone()))?;
 
@@ -46,8 +38,8 @@ fn main() -> Result<(), Box<dyn StdErr>> {
     println!("tx: {}", serde_json::to_string_pretty(&json_tx).unwrap());
 
     let private_key1 = h256!("0x4fd809631a6aa6e3bb378dd65eae5d71df895a82c91a615a1e8264741515c79c");
-    let signer = TransactionSigner::new(&network_info);
-    signer.sign_transaction(
+    let signer1 = TransactionSigner::new(&network_info);
+    signer1.sign_transaction(
         &mut tx_with_groups,
         &SignContexts::new_multisig_h256(&private_key1, multisig_config.clone())?,
     )?;
@@ -55,9 +47,9 @@ fn main() -> Result<(), Box<dyn StdErr>> {
     let json_tx = ckb_jsonrpc_types::TransactionView::from(tx_with_groups.get_tx_view().clone());
     println!("tx: {}", serde_json::to_string_pretty(&json_tx).unwrap());
 
-    let signer = TransactionSigner::new(&network_info);
+    let signer2 = TransactionSigner::new(&network_info);
     let private_key2 = h256!("0x7438f7b35c355e3d2fb9305167a31a72d22ddeafb80a21cc99ff6329d92e8087");
-    signer.sign_transaction(
+    signer2.sign_transaction(
         &mut tx_with_groups,
         &SignContexts::new_multisig_h256(&private_key2, multisig_config)?,
     )?;

--- a/src/tests/transaction/sighash.rs
+++ b/src/tests/transaction/sighash.rs
@@ -1,4 +1,4 @@
-use ckb_types::{core::Capacity, packed::CellOutput, prelude::*};
+use ckb_types::{packed::CellOutput, prelude::*};
 
 use crate::{
     constants::ONE_CKB,
@@ -9,7 +9,7 @@ use crate::{
         builder::{CkbTransactionBuilder, SimpleTransactionBuilder},
         input::InputIterator,
         signer::{SignContexts, TransactionSigner},
-        SmallChangeAction, TransactionBuilderConfiguration,
+        TransactionBuilderConfiguration,
     },
     NetworkInfo,
 };
@@ -41,7 +41,7 @@ fn test_transfer_from_sighash() {
         Box::new(ctx.to_live_cells_context()) as Box<_>,
     );
     let mut builder = SimpleTransactionBuilder::new(configuration, iterator);
-    builder.add_output(output.clone(), ckb_types::packed::Bytes::default());
+    builder.add_output_and_data(output.clone(), ckb_types::packed::Bytes::default());
     builder.set_change_lock(sender.clone());
     let mut tx_with_groups = builder.build(&Default::default()).expect("build failed");
 
@@ -70,130 +70,9 @@ fn test_transfer_from_sighash() {
     assert_eq!(tx.outputs().len(), 2);
     assert_eq!(tx.output(0).unwrap(), output);
     assert_eq!(tx.output(1).unwrap().lock(), sender);
-
-    ctx.verify(tx, FEE_RATE).unwrap();
-}
-
-#[test]
-fn test_transfer_from_sighash_samll_to_fee() {
-    let sender = build_sighash_script(ACCOUNT1_ARG);
-    let receiver = build_sighash_script(ACCOUNT2_ARG);
-    let ctx = init_context(
-        Vec::new(),
-        vec![
-            (sender.clone(), Some(100 * ONE_CKB)),
-            (sender.clone(), Some(200 * ONE_CKB)),
-            (sender.clone(), Some(300 * ONE_CKB)),
-        ],
-    );
-
-    let network_info = NetworkInfo::testnet();
-
-    let output = CellOutput::new_builder()
-        .capacity((299 * ONE_CKB).pack())
-        .lock(receiver)
-        .build();
-    let mut configuration =
-        TransactionBuilderConfiguration::new_with_network(network_info.clone()).unwrap();
-    configuration.small_change_action = SmallChangeAction::AsFee {
-        threshold: Capacity::bytes(1).unwrap().as_u64(),
-    };
-
-    let iterator = InputIterator::new_with_cell_collector(
-        vec![sender.clone()],
-        Box::new(ctx.to_live_cells_context()) as Box<_>,
-    );
-    let mut builder = SimpleTransactionBuilder::new(configuration, iterator);
-    builder.add_output(output.clone(), ckb_types::packed::Bytes::default());
-    builder.set_change_lock(sender.clone());
-    let mut tx_with_groups = builder.build(&Default::default()).expect("build failed");
-
-    let json_tx = ckb_jsonrpc_types::TransactionView::from(tx_with_groups.get_tx_view().clone());
-    println!("tx: {}", serde_json::to_string_pretty(&json_tx).unwrap());
-
-    TransactionSigner::new(&network_info)
-        .sign_transaction(
-            &mut tx_with_groups,
-            &SignContexts::new_sighash_h256(vec![ACCOUNT1_KEY.clone()]).unwrap(),
-        )
-        .unwrap();
-
-    let json_tx = ckb_jsonrpc_types::TransactionView::from(tx_with_groups.get_tx_view().clone());
-    println!("tx: {}", serde_json::to_string_pretty(&json_tx).unwrap());
-
-    let tx = tx_with_groups.get_tx_view().clone();
-    let script_groups = tx_with_groups.script_groups.clone();
-    assert_eq!(script_groups.len(), 1);
-    assert_eq!(tx.header_deps().len(), 0);
-    assert_eq!(tx.cell_deps().len(), 1);
-    assert_eq!(tx.inputs().len(), 2);
-    for out_point in tx.input_pts_iter() {
-        assert_eq!(ctx.get_input(&out_point).unwrap().0.lock(), sender);
-    }
-    assert_eq!(tx.outputs().len(), 1);
-    assert_eq!(tx.output(0).unwrap(), output);
-
-    ctx.verify(tx, FEE_RATE).unwrap();
-}
-
-#[test]
-fn test_transfer_from_sighash_samll_to_receiver() {
-    let sender = build_sighash_script(ACCOUNT1_ARG);
-    let receiver = build_sighash_script(ACCOUNT2_ARG);
-    let ctx = init_context(
-        Vec::new(),
-        vec![
-            (sender.clone(), Some(100 * ONE_CKB)),
-            (sender.clone(), Some(200 * ONE_CKB)),
-            (sender.clone(), Some(300 * ONE_CKB)),
-        ],
-    );
-
-    let network_info = NetworkInfo::testnet();
-
-    let output = CellOutput::new_builder()
-        .capacity((299 * ONE_CKB).pack())
-        .lock(receiver.clone())
-        .build();
-    let mut configuration =
-        TransactionBuilderConfiguration::new_with_network(network_info.clone()).unwrap();
-    configuration.small_change_action =
-        SmallChangeAction::to_output(receiver, Capacity::bytes(1).unwrap().as_u64());
-
-    let iterator = InputIterator::new_with_cell_collector(
-        vec![sender.clone()],
-        Box::new(ctx.to_live_cells_context()) as Box<_>,
-    );
-    let mut builder = SimpleTransactionBuilder::new(configuration, iterator);
-    builder.add_output(output, ckb_types::packed::Bytes::default());
-    builder.set_change_lock(sender.clone());
-    let mut tx_with_groups = builder.build(&Default::default()).expect("build failed");
-
-    let json_tx = ckb_jsonrpc_types::TransactionView::from(tx_with_groups.get_tx_view().clone());
-    println!("tx: {}", serde_json::to_string_pretty(&json_tx).unwrap());
-
-    TransactionSigner::new(&network_info)
-        .sign_transaction(
-            &mut tx_with_groups,
-            &SignContexts::new_sighash_h256(vec![ACCOUNT1_KEY.clone()]).unwrap(),
-        )
-        .unwrap();
-
-    let json_tx = ckb_jsonrpc_types::TransactionView::from(tx_with_groups.get_tx_view().clone());
-    println!("tx: {}", serde_json::to_string_pretty(&json_tx).unwrap());
-
-    let tx = tx_with_groups.get_tx_view().clone();
-    let script_groups = tx_with_groups.script_groups.clone();
-    assert_eq!(script_groups.len(), 1);
-    assert_eq!(tx.header_deps().len(), 0);
-    assert_eq!(tx.cell_deps().len(), 1);
-    assert_eq!(tx.inputs().len(), 2);
-    for out_point in tx.input_pts_iter() {
-        assert_eq!(ctx.get_input(&out_point).unwrap().0.lock(), sender);
-    }
-    assert_eq!(tx.outputs().len(), 1);
-    let actual_output_capacity: u64 = tx.output(0).unwrap().capacity().unpack();
-    assert!(actual_output_capacity > 299 * ONE_CKB);
+    let change_capacity: u64 = tx.output(1).unwrap().capacity().unpack();
+    let fee = (100 + 200 - 120) * ONE_CKB - change_capacity;
+    assert_eq!(tx.data().as_reader().serialized_size_in_block() as u64, fee);
 
     ctx.verify(tx, FEE_RATE).unwrap();
 }

--- a/src/transaction/builder/mod.rs
+++ b/src/transaction/builder/mod.rs
@@ -151,7 +151,7 @@ impl CkbTransactionBuilder for SimpleTransactionBuilder {
             }
             let input_capacity: u64 = previous_output.capacity().unpack();
             inputs_capacity += input_capacity;
-            if inputs_capacity > required_capacity {
+            if inputs_capacity >= required_capacity {
                 has_enough_capacity = true;
                 break;
             }

--- a/src/transaction/builder/mod.rs
+++ b/src/transaction/builder/mod.rs
@@ -9,313 +9,192 @@ use crate::{
     traits::CellCollectorError,
     transaction::TransactionBuilderConfiguration,
     tx_builder::{BalanceTxCapacityError, TxBuilderError},
-    Address, ScriptGroup, TransactionWithScriptGroups,
+    ScriptGroup, TransactionWithScriptGroups,
 };
 use ckb_types::{
-    core::{Capacity, HeaderView},
+    core::Capacity,
     packed::{self, Byte32, CellOutput, Script},
     prelude::{Builder, Entity, Pack, Unpack},
 };
 pub mod fee_calculator;
 pub use fee_calculator::FeeCalculator;
 
+/// CKB transaction builder trait.
 pub trait CkbTransactionBuilder {
     fn build(
-        &mut self,
+        self,
         contexts: &HandlerContexts,
     ) -> Result<TransactionWithScriptGroups, TxBuilderError>;
 }
 
+/// A simple transaction builder implementation, it will build a transaction with enough capacity to pay for the outputs and the fee.
 pub struct SimpleTransactionBuilder {
-    change_output_index: Option<usize>,
-    change_lock: Option<Script>,
+    /// The change lock script, the default change lock script is the last lock script of the input iterator
+    change_lock: Script,
+    /// The transaction builder configuration
     configuration: TransactionBuilderConfiguration,
+    /// Specified transaction inputs, used for building transaction with specific inputs, for example, building a DAO withdraw transaction
     transaction_inputs: Vec<TransactionInput>,
-    input_iter: InputIterator,
-    tx: TransactionBuilder,
+    /// The reward for the DAO withdraw transaction, the default value is 0
     reward: u64,
+    /// The input iterator, used for building transaction with cell collector
+    input_iter: InputIterator,
+    /// The inner transaction builder
+    tx: TransactionBuilder,
 }
 
 impl SimpleTransactionBuilder {
     pub fn new(configuration: TransactionBuilderConfiguration, input_iter: InputIterator) -> Self {
         Self {
-            change_output_index: None,
-            change_lock: None,
+            change_lock: input_iter
+                .lock_scripts()
+                .last()
+                .expect("input iter should not be empty")
+                .clone(),
             configuration,
             transaction_inputs: vec![],
+            reward: 0,
             input_iter,
             tx: TransactionBuilder::default(),
-            reward: 0,
         }
     }
-    pub fn set_change_addr(&mut self, change_addr: &Address) {
-        self.change_lock = Some(change_addr.into());
-    }
 
+    /// Update the change lock script.
     pub fn set_change_lock(&mut self, lock_script: Script) {
-        self.change_lock = Some(lock_script);
+        self.change_lock = lock_script;
     }
 
-    pub fn set_outputs(&mut self, outputs: Vec<CellOutput>, outputs_data: Vec<packed::Bytes>) {
-        self.tx.set_outputs(outputs);
-        self.tx.set_outputs_data(outputs_data);
-    }
-
-    pub fn add_output(&mut self, output: CellOutput, data: packed::Bytes) {
+    /// Add an output cell and output data to the transaction.
+    pub fn add_output_and_data(&mut self, output: CellOutput, data: packed::Bytes) {
         self.tx.output(output);
         self.tx.output_data(data);
     }
 
-    pub fn add_output_from_addr(&mut self, addr: &Address, capacity: Capacity) {
-        self.add_output_from_script(addr.into(), capacity);
-    }
-
-    pub fn add_output_from_script(&mut self, lock_script: Script, capacity: Capacity) {
+    /// Add an output cell with the given lock script and capacity, the type script and the output data are empty.
+    pub fn add_output<S: Into<Script>>(&mut self, output_lock_script: S, capacity: Capacity) {
         let output = CellOutput::new_builder()
             .capacity(capacity.pack())
-            .lock(lock_script)
+            .lock(output_lock_script.into())
             .build();
-        self.add_output(output, packed::Bytes::default());
+        self.add_output_and_data(output, packed::Bytes::default());
     }
-
-    pub fn add_input(&mut self, input: TransactionInput) {
-        self.transaction_inputs.push(input);
-    }
-
-    pub fn add_header_dep(&mut self, header_dep: &HeaderView) {
-        self.tx.dedup_header_dep(header_dep.hash());
-    }
-
-    fn set_change_output_capacity(&mut self, change_capacity: u64) {
-        let mut outputs = self.tx.get_outputs().clone();
-        outputs[self.change_output_index.unwrap()] = outputs
-            [*self.change_output_index.as_ref().unwrap()]
-        .clone()
-        .as_builder()
-        .capacity(change_capacity.pack())
-        .build();
-        self.tx.set_outputs(outputs);
-    }
-
-    fn handle_script(
-        tx_builder: &mut TransactionBuilder,
-        configuration: &TransactionBuilderConfiguration,
-        script_group: &ScriptGroup,
-        contexts: &HandlerContexts,
-    ) -> Result<(), TxBuilderError> {
-        for handler in configuration.get_script_handlers() {
-            for context in &contexts.contexts {
-                if handler.build_transaction(tx_builder, script_group, context.as_ref())? {
-                    break;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn add_output_capacity(
-        tx_builder: &mut TransactionBuilder,
-        script: &Script,
-        delta_capacity: u64,
-    ) -> Result<(), TxBuilderError> {
-        let target_script = script.calc_script_hash();
-        let (idx, output) = tx_builder
-            .get_outputs()
-            .iter()
-            .enumerate()
-            .find(|(_, output)| target_script == output.lock().calc_script_hash())
-            .ok_or(TxBuilderError::NoOutputForSmallChange)?;
-        let capacity: u64 = output.capacity().unpack();
-        let output = output
-            .clone()
-            .as_builder()
-            .capacity((capacity + delta_capacity).pack())
-            .build();
-        tx_builder.set_output(idx, output);
-        Ok(())
-    }
-}
-
-macro_rules! celloutput_capacity {
-    ($output:expr) => {{
-        let tmp_capacity: u64 = $output.capacity().unpack();
-        tmp_capacity
-    }};
 }
 
 impl CkbTransactionBuilder for SimpleTransactionBuilder {
     fn build(
-        &mut self,
+        self,
         contexts: &HandlerContexts,
     ) -> Result<TransactionWithScriptGroups, TxBuilderError> {
+        let Self {
+            change_lock,
+            configuration,
+            transaction_inputs,
+            mut input_iter,
+            mut tx,
+            reward,
+        } = self;
+
         let mut lock_groups: HashMap<Byte32, ScriptGroup> = HashMap::default();
         let mut type_groups: HashMap<Byte32, ScriptGroup> = HashMap::default();
-        let mut outputs_capacity = 0u64;
 
-        for (output_idx, output) in self.tx.get_outputs().clone().iter().enumerate() {
-            outputs_capacity += celloutput_capacity!(output);
-            if let Some(t) = &output.type_().to_opt() {
-                let script_group = type_groups
-                    .entry(t.calc_script_hash())
-                    .or_insert_with(|| ScriptGroup::from_type_script(t));
-                script_group.output_indices.push(output_idx);
-                Self::handle_script(&mut self.tx, &self.configuration, script_group, contexts)?;
+        // setup outputs' type script group
+        let mut outputs_capacity = 0u64;
+        for (output_idx, output) in tx.get_outputs().clone().iter().enumerate() {
+            let output_capacity: u64 = output.capacity().unpack();
+            outputs_capacity += output_capacity;
+            if let Some(type_script) = &output.type_().to_opt() {
+                type_groups
+                    .entry(type_script.calc_script_hash())
+                    .or_insert_with(|| ScriptGroup::from_type_script(type_script))
+                    .output_indices
+                    .push(output_idx);
             }
         }
 
-        let mut state = BalanceState::Init;
+        // setup change output as placeholder with zero capacity
+        let change_output = CellOutput::new_builder().lock(change_lock).build();
+        let occupied_capacity = change_output
+            .occupied_capacity(Capacity::zero())
+            .unwrap()
+            .as_u64();
+        tx.output(change_output);
+        tx.output_data(Default::default());
+
+        // collect inputs
+        let fee_calculator = configuration.fee_calculator();
+        let required_capacity = outputs_capacity
+            + occupied_capacity
+            + fee_calculator.fee(configuration.estimate_tx_size)
+            - reward;
+        let mut has_enough_capacity = false;
         let mut inputs_capacity = 0u64;
-        let mut mini_change_capacity = 0u64;
-        let calculator = self.configuration.fee_calculator();
-        for (input_index, input) in
-            InputView::new(&self.transaction_inputs, &mut self.input_iter).enumerate()
+        for (input_index, input) in InputView::new(&transaction_inputs, &mut input_iter).enumerate()
         {
             let input = input?;
-            self.tx.input(input.cell_input());
+            tx.input(input.cell_input());
+            tx.witness(packed::Bytes::default());
+
             let previous_output = input.previous_output();
-            self.tx.witness(packed::Bytes::default());
             let lock_script = previous_output.lock();
-            let script_group = lock_groups
+            lock_groups
                 .entry(lock_script.calc_script_hash())
-                .or_insert_with(|| ScriptGroup::from_lock_script(&lock_script));
-            script_group.input_indices.push(input_index);
-            // add cellDeps and set witness placeholder
-            Self::handle_script(&mut self.tx, &self.configuration, script_group, contexts)?;
+                .or_insert_with(|| ScriptGroup::from_lock_script(&lock_script))
+                .input_indices
+                .push(input_index);
 
-            if let Some(t) = &previous_output.type_().to_opt() {
-                let script_group = type_groups
-                    .entry(t.calc_script_hash())
-                    .or_insert_with(|| ScriptGroup::from_type_script(t));
-
-                script_group.input_indices.push(input_index);
-                Self::handle_script(&mut self.tx, &self.configuration, script_group, contexts)?;
+            if let Some(type_script) = previous_output.type_().to_opt() {
+                type_groups
+                    .entry(type_script.calc_script_hash())
+                    .or_insert_with(|| ScriptGroup::from_type_script(&type_script))
+                    .input_indices
+                    .push(input_index);
             }
-            inputs_capacity += celloutput_capacity!(previous_output);
-            // check if there is enough capacity for output capacity and change
-            let fee = calculator.fee_with_tx_builder(&self.tx);
-            let change_capacity =
-                (inputs_capacity + self.reward).checked_sub(outputs_capacity + fee);
-            if let Some(mut change_capacity) = change_capacity {
-                if self.change_output_index.is_none() {
-                    // it's already balanced, no need to add change output cell
-                    if change_capacity == 0 {
-                        state = BalanceState::Success;
-                        break;
-                    }
-                    match self.configuration.small_change_action {
-                        super::SmallChangeAction::FindMoreInput => {}
-                        super::SmallChangeAction::ToOutput {
-                            ref target,
-                            threshold,
-                        } => {
-                            if change_capacity < threshold {
-                                Self::add_output_capacity(&mut self.tx, target, change_capacity)?;
-                                state = BalanceState::Success;
-                                break;
-                            }
-                        }
-                        super::SmallChangeAction::AsFee { threshold } => {
-                            if change_capacity < threshold {
-                                state = BalanceState::Success;
-                                break;
-                            }
-                        }
-                    }
-                    {
-                        // init change
-                        let change_output = CellOutput::new_builder()
-                            .capacity(Capacity::bytes(0).unwrap().pack())
-                            .lock(self.change_lock.as_ref().unwrap().clone())
-                            .build();
-                        let change_output_data = packed::Bytes::default();
-                        mini_change_capacity = change_output
-                            .occupied_capacity(Capacity::bytes(change_output_data.len()).unwrap())
-                            .unwrap()
-                            .as_u64();
-                        self.change_output_index = Some(self.tx.get_outputs().len());
-                        self.tx.output(change_output);
-                        self.tx.output_data(change_output_data);
-                    }
-                    let new_fee = calculator.fee_with_tx_builder(&self.tx);
-                    if let Some(new_change) =
-                        (inputs_capacity + self.reward).checked_sub(outputs_capacity + new_fee)
-                    {
-                        change_capacity = new_change;
-                    } else {
-                        state = BalanceState::CapacityNotEnoughForChange(
-                            mini_change_capacity + new_fee - fee,
-                            change_capacity,
-                        );
-                        continue;
-                    }
-                }
-                if change_capacity >= mini_change_capacity {
-                    self.set_change_output_capacity(change_capacity);
-                    state = BalanceState::Success;
-                    break;
-                } else {
-                    state = BalanceState::CapacityNotEnoughForChange(
-                        mini_change_capacity,
-                        change_capacity,
-                    );
-                }
-            } else {
-                state = BalanceState::CapacityNotEnough(
-                    (outputs_capacity + fee) - (inputs_capacity + self.reward),
-                );
+            let input_capacity: u64 = previous_output.capacity().unpack();
+            inputs_capacity += input_capacity;
+            if inputs_capacity > required_capacity {
+                has_enough_capacity = true;
+                break;
             }
         }
 
-        if !state.is_success() {
-            return Err(TxBuilderError::BalanceCapacity(state.into()));
+        if !has_enough_capacity {
+            return Err(BalanceTxCapacityError::CapacityNotEnough(format!(
+                "can not find enough inputs, inputs_capacity: {}, required_capacity: {}",
+                inputs_capacity, required_capacity
+            ))
+            .into());
         }
+
+        // handle script groups
         let script_groups = lock_groups
             .into_values()
             .chain(type_groups.into_values())
             .collect();
-        Ok(TransactionWithScriptGroups::new(
-            self.tx.clone().build(),
-            script_groups,
-        ))
-    }
-}
 
-enum BalanceState {
-    Init,
-    Success,
-    // (left_capacity)
-    CapacityNotEnough(u64),
-    // (required_capacity, change_capacity)
-    CapacityNotEnoughForChange(u64, u64),
-}
-impl BalanceState {
-    #[inline]
-    fn is_success(&self) -> bool {
-        matches!(self, BalanceState::Success)
-    }
-}
-
-impl From<BalanceState> for BalanceTxCapacityError {
-    fn from(val: BalanceState) -> Self {
-        BalanceTxCapacityError::CapacityNotEnough(val.to_string())
-    }
-}
-
-impl ToString for BalanceState {
-    fn to_string(&self) -> String {
-        match self {
-            BalanceState::Init => "Init".to_string(),
-            BalanceState::Success => "Success".to_string(),
-            BalanceState::CapacityNotEnough(left_capacity) => {
-                format!("CapacityNotEnough, left_capacity: {}", left_capacity)
-            }
-            BalanceState::CapacityNotEnoughForChange(required_capacity, change_capacity) => {
-                format!(
-                    "CapacityNotEnoughForChange, required_capacity: {}, change_capacity: {}",
-                    required_capacity, change_capacity
-                )
+        for script_group in &script_groups {
+            for handler in configuration.get_script_handlers() {
+                for context in &contexts.contexts {
+                    if handler.build_transaction(&mut tx, script_group, context.as_ref())? {
+                        break;
+                    }
+                }
             }
         }
+
+        // update change output capacity to real value
+        let fee = fee_calculator.fee_with_tx_builder(&tx);
+        let change_capacity = inputs_capacity + reward - outputs_capacity - fee;
+        let change_output = tx
+            .outputs
+            .last()
+            .unwrap()
+            .clone()
+            .as_builder()
+            .capacity(change_capacity.pack())
+            .build();
+        tx.set_output(tx.outputs.len() - 1, change_output);
+
+        Ok(TransactionWithScriptGroups::new(tx.build(), script_groups))
     }
 }
 

--- a/src/transaction/input/mod.rs
+++ b/src/transaction/input/mod.rs
@@ -45,6 +45,10 @@ impl InputIterator {
         Self::new(lock_scripts, network_info)
     }
 
+    pub fn lock_scripts(&self) -> &[packed::Script] {
+        &self.lock_scripts
+    }
+
     fn collect_live_cells_by_lock(
         cell_collector: &mut Box<dyn CellCollector>,
         buffer_inputs: &mut Vec<TransactionInput>,


### PR DESCRIPTION
This PR refactors `SimpleTransactionBuilder` to simplify the process of building transactions by introducing the `estimate_tx_size` parameter, which makes building transactions simpler and more flexible. the `SmallChangeAction` struct in the original code is an edge case in real-world scenarios for sdk, and is only used when the user needs to transfer all ckb capacity from one address to another address. putting the processing logic of this edge scenario into `SimpleTransactionBuilder` introduces unnecessary complexity, and if needed, we can introduce another builder to specifically handle this requirement via PR later.