### PR TITLE
Fix CI `security-audit` failed to install `cargo-deny`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,8 +52,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Security Audit & Licenses
       run: |
-        rustup toolchain install nightly --allow-downgrade --profile minimal
-        cargo deny --version || cargo +nightly install cargo-deny --locked
+        rustup toolchain install stable --profile minimal
+        cargo deny --version || cargo install cargo-deny --locked
         make security-audit
         make check-crates
         make check-licenses


### PR DESCRIPTION
This [CI job](https://github.com/nervosnetwork/ckb-sdk-rust/actions/runs/5550747875/jobs/10136171728?pr=80) failed, because CI failed to install `cargo-deny`.

Request for review. @quake 