### PR TITLE
fix: rpc method generate_block has no params

### DIFF
--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -87,7 +87,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     // IntegrationTest
     pub fn process_block_without_verify(&self, data: Block, broadcast: bool) -> Option<H256>;
     pub fn truncate(&self, target_tip_hash: H256) -> ();
-    pub fn generate_block(&self, block_assembler_script: Option<Script>, block_assembler_message: Option<JsonBytes>) -> H256;
+    pub fn generate_block(&self) -> H256;
     pub fn notify_transaction(&self, tx: Transaction) -> H256;
 
     // Debug

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -2,7 +2,7 @@ use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockResponse, BlockTemplate,
     BlockView, CellWithStatus, ChainInfo, Consensus, EpochNumber, EpochView, EstimateCycles,
     ExtraLoggerConfig, FeeRateStatics, HeaderView, JsonBytes, LocalNode, MainLoggerConfig,
-    OutPoint, OutputsValidator, RawTxPool, RemoteNode, Script, SyncState, Timestamp, Transaction,
+    OutPoint, OutputsValidator, RawTxPool, RemoteNode, SyncState, Timestamp, Transaction,
     TransactionAndWitnessProof, TransactionProof, TransactionWithStatusResponse, TxPoolInfo,
     Uint32, Uint64, Version,
 };


### PR DESCRIPTION
https://github.com/nervosnetwork/ckb/blob/4acac3aeb39721d66840216b4d983d20c266a500/rpc/src/module/test.rs#L177