### PR TITLE
Support more RPC for ckb and ckb-light-client

### DIFF
--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -220,10 +220,11 @@ impl CkbRpcClient {
     pub fn get_transaction_status(
         &self,
         hash: H256,
+        only_committed: Option<bool>,
     ) -> Result<TransactionWithStatusResponse, crate::rpc::RpcError> {
         self.post::<_, TransactionWithStatusResponse>(
             "get_transaction",
-            (hash, Some(Uint32::from(1u32))),
+            (hash, Some(Uint32::from(1u32)), only_committed),
         )
     }
 

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -91,7 +91,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     // IntegrationTest
     pub fn process_block_without_verify(&self, data: Block, broadcast: bool) -> Option<H256>;
     pub fn truncate(&self, target_tip_hash: H256) -> ();
-    pub fn generate_block(&self, block_assembler_script: Option<Script>, block_assembler_message: Option<JsonBytes>) -> H256;
+    pub fn generate_block(&self) -> H256;
     pub fn notify_transaction(&self, tx: Transaction) -> H256;
     pub fn calculate_dao_field(&self, block_template: BlockTemplate) -> JsonBytes;
     pub fn generate_block_with_template(&self, block_template: BlockTemplate) -> H256;

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -208,10 +208,11 @@ impl CkbRpcClient {
     pub fn get_packed_transaction(
         &self,
         hash: H256,
+        only_committed: Option<bool>,
     ) -> Result<TransactionWithStatusResponse, crate::rpc::RpcError> {
         self.post::<_, TransactionWithStatusResponse>(
             "get_transaction",
-            (hash, Some(Uint32::from(0u32))),
+            (hash, Some(Uint32::from(0u32)), only_committed),
         )
     }
 

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -102,7 +102,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     pub fn set_extra_logger(&self, name: String, config_opt: Option<ExtraLoggerConfig>) -> ();
 
     // Experimental
-    fn calculate_dao_maximum_withdraw(&self, out_point: OutPoint, kind: DaoWithdrawingCalculationKind) -> Capacity;
+    pub fn calculate_dao_maximum_withdraw(&self, out_point: OutPoint, kind: DaoWithdrawingCalculationKind) -> Capacity;
 });
 
 fn transform_cycles(cycles: Option<Vec<ckb_jsonrpc_types::Cycle>>) -> Vec<Cycle> {

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -93,6 +93,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     pub fn generate_block(&self, block_assembler_script: Option<Script>, block_assembler_message: Option<JsonBytes>) -> H256;
     pub fn notify_transaction(&self, tx: Transaction) -> H256;
     pub fn calculate_dao_field(&self, block_template: BlockTemplate) -> Byte32;
+    pub fn generate_block_with_template(&self, block_template: BlockTemplate) -> H256;
 
     // Debug
     pub fn jemalloc_profiling_dump(&self) -> String;

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -93,7 +93,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     pub fn truncate(&self, target_tip_hash: H256) -> ();
     pub fn generate_block(&self, block_assembler_script: Option<Script>, block_assembler_message: Option<JsonBytes>) -> H256;
     pub fn notify_transaction(&self, tx: Transaction) -> H256;
-    pub fn calculate_dao_field(&self, block_template: BlockTemplate) -> Byte32;
+    pub fn calculate_dao_field(&self, block_template: BlockTemplate) -> JsonBytes;
     pub fn generate_block_with_template(&self, block_template: BlockTemplate) -> H256;
 
     // Debug

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -1,10 +1,10 @@
 use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockResponse, BlockTemplate,
-    BlockView, CellWithStatus, ChainInfo, Consensus, DeploymentsInfo, EpochNumber, EpochView,
-    EstimateCycles, ExtraLoggerConfig, FeeRateStatistics, HeaderView, JsonBytes, LocalNode,
-    MainLoggerConfig, OutPoint, OutputsValidator, RawTxPool, RemoteNode, Script, SyncState,
-    Timestamp, Transaction, TransactionAndWitnessProof, TransactionProof,
-    TransactionWithStatusResponse, TxPoolInfo, Uint32, Uint64, Version,
+    BlockView, CellWithStatus, ChainInfo, Consensus, DaoWithdrawingCalculationKind,
+    DeploymentsInfo, EpochNumber, EpochView, EstimateCycles, ExtraLoggerConfig, FeeRateStatistics,
+    HeaderView, JsonBytes, LocalNode, MainLoggerConfig, OutPoint, OutputsValidator, RawTxPool,
+    RemoteNode, Script, SyncState, Timestamp, Transaction, TransactionAndWitnessProof,
+    TransactionProof, TransactionWithStatusResponse, TxPoolInfo, Uint32, Uint64, Version,
 };
 use ckb_types::{core::Cycle, H256};
 
@@ -97,6 +97,9 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     pub fn jemalloc_profiling_dump(&self) -> String;
     pub fn update_main_logger(&self, config: MainLoggerConfig) -> ();
     pub fn set_extra_logger(&self, name: String, config_opt: Option<ExtraLoggerConfig>) -> ();
+
+    // Experimental
+    fn calculate_dao_maximum_withdraw(&self, out_point: OutPoint, kind: DaoWithdrawingCalculationKind) -> Capacity;
 });
 
 fn transform_cycles(cycles: Option<Vec<ckb_jsonrpc_types::Cycle>>) -> Vec<Cycle> {

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -91,6 +91,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     pub fn truncate(&self, target_tip_hash: H256) -> ();
     pub fn generate_block(&self, block_assembler_script: Option<Script>, block_assembler_message: Option<JsonBytes>) -> H256;
     pub fn notify_transaction(&self, tx: Transaction) -> H256;
+    pub fn calculate_dao_field(&self, block_template: BlockTemplate) -> Byte32;
 
     // Debug
     pub fn jemalloc_profiling_dump(&self) -> String;

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -25,7 +25,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     pub fn get_live_cell(&self, out_point: OutPoint, with_data: bool) -> CellWithStatus;
     pub fn get_tip_block_number(&self) -> BlockNumber;
     pub fn get_tip_header(&self) -> HeaderView;
-    pub fn get_transaction(&self, hash: H256) -> Option<TransactionWithStatusResponse>;
+    pub fn get_transaction(&self, hash: H256, only_committed: Option<bool>) -> Option<TransactionWithStatusResponse>;
     pub fn get_transaction_proof(
         &self,
         tx_hashes: Vec<H256>,

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -1,10 +1,11 @@
 use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockFilter, BlockNumber, BlockResponse,
-    BlockTemplate, BlockView, CellWithStatus, ChainInfo, Consensus, DaoWithdrawingCalculationKind,
-    DeploymentsInfo, EpochNumber, EpochView, EstimateCycles, ExtraLoggerConfig, FeeRateStatistics,
-    HeaderView, JsonBytes, LocalNode, MainLoggerConfig, OutPoint, OutputsValidator, RawTxPool,
-    RemoteNode, Script, SyncState, Timestamp, Transaction, TransactionAndWitnessProof,
-    TransactionProof, TransactionWithStatusResponse, TxPoolInfo, Uint32, Uint64, Version,
+    BlockTemplate, BlockView, Capacity, CellWithStatus, ChainInfo, Consensus,
+    DaoWithdrawingCalculationKind, DeploymentsInfo, EpochNumber, EpochView, EstimateCycles,
+    ExtraLoggerConfig, FeeRateStatistics, HeaderView, JsonBytes, LocalNode, MainLoggerConfig,
+    OutPoint, OutputsValidator, RawTxPool, RemoteNode, Script, SyncState, Timestamp, Transaction,
+    TransactionAndWitnessProof, TransactionProof, TransactionWithStatusResponse, TxPoolInfo,
+    Uint32, Uint64, Version,
 };
 use ckb_types::{core::Cycle, H256};
 

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -26,7 +26,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     pub fn get_live_cell(&self, out_point: OutPoint, with_data: bool) -> CellWithStatus;
     pub fn get_tip_block_number(&self) -> BlockNumber;
     pub fn get_tip_header(&self) -> HeaderView;
-    pub fn get_transaction(&self, hash: H256, only_committed: Option<bool>) -> Option<TransactionWithStatusResponse>;
+    pub fn get_transaction(&self, hash: H256) -> Option<TransactionWithStatusResponse>;
     pub fn get_transaction_proof(
         &self,
         tx_hashes: Vec<H256>,
@@ -206,15 +206,37 @@ impl CkbRpcClient {
             (number, Some(Uint32::from(0u32))),
         )
     }
+
+    // get transaction with only_committed=true
+    pub fn get_only_committed_transaction(
+        &self,
+        hash: H256,
+    ) -> Result<TransactionWithStatusResponse, crate::rpc::RpcError> {
+        self.post::<_, TransactionWithStatusResponse>(
+            "get_transaction",
+            (hash, Some(Uint32::from(2u32)), true),
+        )
+    }
+
     // get transaction with verbosity=0
     pub fn get_packed_transaction(
         &self,
         hash: H256,
-        only_committed: Option<bool>,
     ) -> Result<TransactionWithStatusResponse, crate::rpc::RpcError> {
         self.post::<_, TransactionWithStatusResponse>(
             "get_transaction",
-            (hash, Some(Uint32::from(0u32)), only_committed),
+            (hash, Some(Uint32::from(0u32))),
+        )
+    }
+
+    // get transaction with verbosity=0 and only_committed=true
+    pub fn get_only_committed_packed_transaction(
+        &self,
+        hash: H256,
+    ) -> Result<TransactionWithStatusResponse, crate::rpc::RpcError> {
+        self.post::<_, TransactionWithStatusResponse>(
+            "get_transaction",
+            (hash, Some(Uint32::from(0u32)), true),
         )
     }
 
@@ -222,11 +244,21 @@ impl CkbRpcClient {
     pub fn get_transaction_status(
         &self,
         hash: H256,
-        only_committed: Option<bool>,
     ) -> Result<TransactionWithStatusResponse, crate::rpc::RpcError> {
         self.post::<_, TransactionWithStatusResponse>(
             "get_transaction",
-            (hash, Some(Uint32::from(1u32)), only_committed),
+            (hash, Some(Uint32::from(1u32))),
+        )
+    }
+
+    // get transaction with verbosity=1 and only_committed=true, so the result transaction field is None
+    pub fn get_only_committed_transaction_status(
+        &self,
+        hash: H256,
+    ) -> Result<TransactionWithStatusResponse, crate::rpc::RpcError> {
+        self.post::<_, TransactionWithStatusResponse>(
+            "get_transaction",
+            (hash, Some(Uint32::from(1u32)), true),
         )
     }
 

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -1,6 +1,6 @@
 use ckb_jsonrpc_types::{
-    Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockResponse, BlockTemplate,
-    BlockView, CellWithStatus, ChainInfo, Consensus, DaoWithdrawingCalculationKind,
+    Alert, BannedAddr, Block, BlockEconomicState, BlockFilter, BlockNumber, BlockResponse,
+    BlockTemplate, BlockView, CellWithStatus, ChainInfo, Consensus, DaoWithdrawingCalculationKind,
     DeploymentsInfo, EpochNumber, EpochView, EstimateCycles, ExtraLoggerConfig, FeeRateStatistics,
     HeaderView, JsonBytes, LocalNode, MainLoggerConfig, OutPoint, OutputsValidator, RawTxPool,
     RemoteNode, Script, SyncState, Timestamp, Transaction, TransactionAndWitnessProof,
@@ -17,6 +17,7 @@ crate::jsonrpc!(pub struct CkbRpcClient {
     pub fn get_block(&self, hash: H256) -> Option<BlockView>;
     pub fn get_block_by_number(&self, number: BlockNumber) -> Option<BlockView>;
     pub fn get_block_hash(&self, number: BlockNumber) -> Option<H256>;
+    pub fn get_block_filter(&self, block_hash: H256) -> Option<BlockFilter>;
     pub fn get_current_epoch(&self) -> EpochView;
     pub fn get_epoch_by_number(&self, number: EpochNumber) -> Option<EpochView>;
     pub fn get_header(&self, hash: H256) -> Option<HeaderView>;

--- a/src/rpc/ckb.rs
+++ b/src/rpc/ckb.rs
@@ -3,7 +3,7 @@ use ckb_jsonrpc_types::{
     BlockTemplate, BlockView, Capacity, CellWithStatus, ChainInfo, Consensus,
     DaoWithdrawingCalculationKind, DeploymentsInfo, EpochNumber, EpochView, EstimateCycles,
     ExtraLoggerConfig, FeeRateStatistics, HeaderView, JsonBytes, LocalNode, MainLoggerConfig,
-    OutPoint, OutputsValidator, RawTxPool, RemoteNode, Script, SyncState, Timestamp, Transaction,
+    OutPoint, OutputsValidator, RawTxPool, RemoteNode, SyncState, Timestamp, Transaction,
     TransactionAndWitnessProof, TransactionProof, TransactionWithStatusResponse, TxPoolInfo,
     Uint32, Uint64, Version,
 };

--- a/src/rpc/ckb_light_client.rs
+++ b/src/rpc/ckb_light_client.rs
@@ -17,6 +17,17 @@ pub struct ScriptStatus {
     pub block_number: BlockNumber,
 }
 
+#[derive(Deserialize, Serialize, Eq, PartialEq, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum SetScriptsCommand {
+    // Replace all scripts with new scripts, non-exist scripts will be deleted
+    All,
+    // Update partial scripts with new scripts, non-exist scripts will be ignored
+    Partial,
+    // Delete scripts, non-exist scripts will be ignored
+    Delete,
+}
+
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 #[serde(tag = "status")]
 #[serde(rename_all = "snake_case")]
@@ -88,7 +99,7 @@ pub struct PeerSyncState {
 
 crate::jsonrpc!(pub struct LightClientRpcClient {
     // BlockFilter
-    pub fn set_scripts(&self, scripts: Vec<ScriptStatus>) -> ();
+    pub fn set_scripts(&self, scripts: Vec<ScriptStatus>, command: Option<SetScriptsCommand>) -> ();
     pub fn get_scripts(&self) -> Vec<ScriptStatus>;
     pub fn get_cells(&self, search_key: SearchKey, order: Order, limit: Uint32, after: Option<JsonBytes>) -> Pagination<Cell>;
     pub fn get_transactions(&self, search_key: SearchKey, order: Order, limit: Uint32, after: Option<JsonBytes>) -> Pagination<Tx>;

--- a/src/rpc/ckb_light_client.rs
+++ b/src/rpc/ckb_light_client.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use ckb_jsonrpc_types::{
-    BlockNumber, BlockView, HeaderView, JsonBytes, NodeAddress, RemoteNodeProtocol, Script,
-    Transaction, TransactionView, Uint32, Uint64,
+    BlockNumber, BlockView, Cycle, HeaderView, JsonBytes, NodeAddress, RemoteNodeProtocol, Script,
+    Transaction, TransactionView, TxStatus, Uint32, Uint64,
 };
 use ckb_types::H256;
 
@@ -123,7 +123,7 @@ crate::jsonrpc!(pub struct LightClientRpcClient {
     /// Fetch a transaction from remote node. If return status is `not_found` will re-sent fetching request immediately.
     ///
     /// Returns: FetchStatus<TransactionWithHeader>
-    pub fn fetch_transaction(&self, tx_hash: H256) -> FetchStatus<TransactionWithHeader>;
+    pub fn fetch_transaction(&self, tx_hash: H256) -> FetchStatus<TransactionWithStatus>;
 
     // Net
     pub fn get_peers(&self) -> Vec<RemoteNode>;

--- a/src/rpc/ckb_light_client.rs
+++ b/src/rpc/ckb_light_client.rs
@@ -42,6 +42,7 @@ pub enum FetchStatus<T> {
 pub struct TransactionWithStatus {
     pub(crate) transaction: Option<TransactionView>,
     pub(crate) cycles: Option<Cycle>,
+    pub(crate) time_added_to_pool: Option<Uint64>,
     pub(crate) tx_status: TxStatus,
 }
 
@@ -113,7 +114,7 @@ crate::jsonrpc!(pub struct LightClientRpcClient {
     pub fn get_tip_header(&self) -> HeaderView;
     pub fn get_genesis_block(&self) -> BlockView;
     pub fn get_header(&self, block_hash: H256) -> Option<HeaderView>;
-    pub fn get_transaction(&self, tx_hash: H256) -> Option<TransactionWithHeader>;
+    pub fn get_transaction(&self, tx_hash: H256) -> Option<TransactionWithStatus>;
     /// Fetch a header from remote node. If return status is `not_found` will re-sent fetching request immediately.
     ///
     /// Returns: FetchStatus<HeaderView>

--- a/src/rpc/ckb_light_client.rs
+++ b/src/rpc/ckb_light_client.rs
@@ -39,9 +39,10 @@ pub enum FetchStatus<T> {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
-pub struct TransactionWithHeader {
-    pub transaction: TransactionView,
-    pub header: HeaderView,
+pub struct TransactionWithStatus {
+    pub(crate) transaction: Option<TransactionView>,
+    pub(crate) cycles: Option<Cycle>,
+    pub(crate) tx_status: TxStatus,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/rpc/ckb_light_client.rs
+++ b/src/rpc/ckb_light_client.rs
@@ -89,6 +89,43 @@ pub struct RemoteNode {
     pub protocols: Vec<RemoteNodeProtocol>,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct LocalNode {
+    /// light client node version.
+    ///
+    /// Example: "version": "0.2.0"
+    pub version: String,
+    /// The unique node ID derived from the p2p private key.
+    ///
+    /// The private key is generated randomly on the first boot.
+    pub node_id: String,
+    /// Whether this node is active.
+    ///
+    /// An inactive node ignores incoming p2p messages and drops outgoing messages.
+    pub active: bool,
+    /// P2P addresses of this node.
+    ///
+    /// A node can have multiple addresses.
+    pub addresses: Vec<NodeAddress>,
+    /// Supported protocols.
+    pub protocols: Vec<LocalNodeProtocol>,
+    /// Count of currently connected peers.
+    pub connections: Uint64,
+}
+
+/// The information of a P2P protocol that is supported by the local node.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct LocalNodeProtocol {
+    /// Unique protocol ID.
+    pub id: Uint64,
+    /// Readable protocol name.
+    pub name: String,
+    /// Supported versions.
+    ///
+    /// See [Semantic Version](https://semver.org/) about how to specify a version.
+    pub support_versions: Vec<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeerSyncState {
     /// Requested best known header of remote peer.
@@ -127,4 +164,5 @@ crate::jsonrpc!(pub struct LightClientRpcClient {
 
     // Net
     pub fn get_peers(&self) -> Vec<RemoteNode>;
+    pub fn local_node_info(&self) -> LocalNode;
 });


### PR DESCRIPTION
This PR want to close #94 and https://github.com/nervosnetwork/ckb-sdk-rust/issues/97 

- [x] CKB
  - [x] calculate_dao_field
  - [x] calculate_dao_maximum_withdraw
  - [x] ~~dry_run_transaction (deprecated)~~
  - [x] generate_block currently does not support passing a warehouse
  - [x] generate_block_with_template
  - [x] get_block_filter
  - [x] get_fee_rate_statics(&self, tartet: Option) -> FeeRateStatistics
	- [x] Typo in "tartet"
  - [x] FeeRateStatistics should be an Option
    - [x] get_fee_rate_statistics, same as get_fee_rate_statics
    - [x] get_transaction does not support the "only_committed" parameter

- [x] CKB Light Client
  - [x] fetch_transaction: it should be TransactionWithStatus, not TransactionWithHeader.
  - [x] get_transaction: it should be TransactionWithStatus, not TransactionWithHeader.
  - [x] set_script: not support SetScriptCommand
  - [x] local_node_info: not support now
