### PR TITLE
[BREAKING CHANGE] Extend Indexer PRC `SearchKey` for CKB 0.114

### DIFF
--- a/src/rpc/ckb_indexer.rs
+++ b/src/rpc/ckb_indexer.rs
@@ -39,6 +39,8 @@ impl Default for SearchMode {
 pub struct SearchKeyFilter {
     pub script: Option<Script>,
     pub script_len_range: Option<[Uint64; 2]>,
+    pub output_data: Option<JsonBytes>,
+    pub output_data_filter_mode: Option<SearchMode>,
     pub output_data_len_range: Option<[Uint64; 2]>,
     pub output_capacity_range: Option<[Uint64; 2]>,
     pub block_range: Option<[BlockNumber; 2]>,
@@ -58,6 +60,8 @@ impl From<CellQueryOptions> for SearchKey {
             Some(SearchKeyFilter {
                 script: opts.secondary_script.map(|v| v.into()),
                 script_len_range: opts.secondary_script_len_range.map(convert_range),
+                output_data: None,
+                output_data_filter_mode: None,
                 output_data_len_range: opts.data_len_range.map(convert_range),
                 output_capacity_range: opts.capacity_range.map(convert_range),
                 block_range: opts.block_range.map(convert_range),

--- a/src/rpc/ckb_indexer.rs
+++ b/src/rpc/ckb_indexer.rs
@@ -12,7 +12,7 @@ use crate::traits::{CellQueryOptions, LiveCell, PrimaryScriptType, ValueRangeOpt
 pub struct SearchKey {
     pub script: Script,
     pub script_type: ScriptType,
-    pub script_search_mode: Option<ScriptSearchMode>,
+    pub script_search_mode: Option<SearchMode>,
     pub filter: Option<SearchKeyFilter>,
     pub with_data: Option<bool>,
     pub group_by_transaction: Option<bool>,
@@ -20,14 +20,16 @@ pub struct SearchKey {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
 #[serde(rename_all = "snake_case")]
-pub enum ScriptSearchMode {
-    // search script with prefix
+pub enum SearchMode {
+    // search with prefix
     Prefix,
-    // search script with exact match
+    // search with exact match
     Exact,
+    // search with partial match
+    Partial,
 }
 
-impl Default for ScriptSearchMode {
+impl Default for SearchMode {
     fn default() -> Self {
         Self::Prefix
     }

--- a/src/tests/ckb_indexer_rpc.rs
+++ b/src/tests/ckb_indexer_rpc.rs
@@ -1,6 +1,6 @@
 use crate::{
     rpc::{
-        ckb_indexer::{Order, ScriptSearchMode, SearchKey},
+        ckb_indexer::{Order, SearchKey, SearchMode},
         CkbRpcClient,
     },
     traits::{CellQueryOptions, ValueRangeOption},
@@ -66,7 +66,7 @@ fn test_cells_search_mode_prefix_partitial() {
 
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
     query.block_range = block_range;
-    query.script_search_mode = Some(ScriptSearchMode::Prefix);
+    query.script_search_mode = Some(SearchMode::Prefix);
     query.min_total_capacity = u64::MAX;
 
     let search_key = SearchKey::from(query);
@@ -87,7 +87,7 @@ fn test_cells_search_mode_exact_partitial() {
         .build();
     // exact with partitial args
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
-    query.script_search_mode = Some(ScriptSearchMode::Exact);
+    query.script_search_mode = Some(SearchMode::Exact);
     query.block_range = block_range;
     query.min_total_capacity = u64::MAX;
 
@@ -109,7 +109,7 @@ fn test_cells_search_mode_exact() {
         .build();
 
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
-    query.script_search_mode = Some(ScriptSearchMode::Exact);
+    query.script_search_mode = Some(SearchMode::Exact);
     query.block_range = block_range;
     query.min_total_capacity = u64::MAX;
 
@@ -156,7 +156,7 @@ fn test_get_transactions_search_mode_prefix_partial() {
 
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
     query.block_range = block_range;
-    query.script_search_mode = Some(ScriptSearchMode::Prefix);
+    query.script_search_mode = Some(SearchMode::Prefix);
     query.min_total_capacity = u64::MAX;
 
     let search_key = SearchKey::from(query);
@@ -177,7 +177,7 @@ fn test_get_transactions_search_mode_exact_partitial() {
         .build();
 
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
-    query.script_search_mode = Some(ScriptSearchMode::Exact);
+    query.script_search_mode = Some(SearchMode::Exact);
     query.block_range = block_range;
     query.min_total_capacity = u64::MAX;
 
@@ -200,7 +200,7 @@ fn test_get_transactions_search_mode_exact_full() {
         .build();
 
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
-    query.script_search_mode = Some(ScriptSearchMode::Exact);
+    query.script_search_mode = Some(SearchMode::Exact);
     query.block_range = block_range;
     query.min_total_capacity = u64::MAX;
 
@@ -244,7 +244,7 @@ fn test_get_cells_capacity_search_mode_prefix_partial() {
 
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
     query.block_range = block_range;
-    query.script_search_mode = Some(ScriptSearchMode::Prefix);
+    query.script_search_mode = Some(SearchMode::Prefix);
     query.min_total_capacity = u64::MAX;
 
     let search_key = SearchKey::from(query);
@@ -264,7 +264,7 @@ fn test_get_cells_capacity_search_mode_exact_partital() {
         .build();
     // exact with partitial args
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
-    query.script_search_mode = Some(ScriptSearchMode::Exact);
+    query.script_search_mode = Some(SearchMode::Exact);
     query.block_range = block_range;
     query.min_total_capacity = u64::MAX;
 
@@ -285,7 +285,7 @@ fn test_get_cells_capacity_search_mode_exact() {
         .build();
 
     let mut query = CellQueryOptions::new(script, crate::traits::PrimaryScriptType::Type);
-    query.script_search_mode = Some(ScriptSearchMode::Exact);
+    query.script_search_mode = Some(SearchMode::Exact);
     query.block_range = block_range;
     query.min_total_capacity = u64::MAX;
 

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -35,7 +35,7 @@ use ckb_types::{
     prelude::*,
 };
 
-use crate::{rpc::ckb_indexer::ScriptSearchMode, util::is_mature};
+use crate::{rpc::ckb_indexer::SearchMode, util::is_mature};
 
 /// Signer errors
 #[derive(Error, Debug)]
@@ -256,7 +256,7 @@ pub struct CellQueryOptions {
     /// satisfied will stop collecting. The default value is 1 shannon means
     /// collect only one cell at most.
     pub min_total_capacity: u64,
-    pub script_search_mode: Option<ScriptSearchMode>,
+    pub script_search_mode: Option<SearchMode>,
 }
 impl CellQueryOptions {
     pub fn new(primary_script: Script, primary_type: PrimaryScriptType) -> CellQueryOptions {

--- a/src/transaction/input/mod.rs
+++ b/src/transaction/input/mod.rs
@@ -3,7 +3,7 @@ use ckb_types::packed::Script;
 pub use transaction_input::TransactionInput;
 
 use crate::{
-    rpc::ckb_indexer::ScriptSearchMode,
+    rpc::ckb_indexer::SearchMode,
     traits::{
         CellCollector, CellCollectorError, CellQueryOptions, DefaultCellCollector, ValueRangeOption,
     },
@@ -76,7 +76,7 @@ impl InputIterator {
         loop {
             if let Some(lock_script) = self.lock_scripts.last() {
                 let mut query = CellQueryOptions::new_lock(lock_script.clone());
-                query.script_search_mode = Some(ScriptSearchMode::Exact);
+                query.script_search_mode = Some(SearchMode::Exact);
                 if let Some(type_script) = &self.type_script {
                     query.secondary_script = Some(type_script.clone());
                 } else {


### PR DESCRIPTION
Updates:

- Extended the enumeration values for `Partial` in `SearchMode`
- Extended the `output_data` and `output_data_filter_mode` fields for the `SearchKeyFilter`

BREAKING CHANGE: rename `ScriptSearchMode` -> `SearchMode`