### PR TITLE
refactor: remove the `tx` parameter from the `sign` method in the `Signer` trait

### DIFF
--- a/src/traits/default_impls.rs
+++ b/src/traits/default_impls.rs
@@ -614,13 +614,7 @@ impl Signer for SecpCkbRawKeySigner {
         id.len() == 20 && self.keys.contains_key(&H160::from_slice(id).unwrap())
     }
 
-    fn sign(
-        &self,
-        id: &[u8],
-        message: &[u8],
-        recoverable: bool,
-        _tx: &TransactionView,
-    ) -> Result<Bytes, SignerError> {
+    fn sign(&self, id: &[u8], message: &[u8], recoverable: bool) -> Result<Bytes, SignerError> {
         if !self.match_id(id) {
             return Err(SignerError::IdNotFound);
         }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -67,13 +67,7 @@ pub trait Signer {
     /// different length of message:
     ///   * secp256k1 => 256bits
     ///   * RSA       => 512bits (when key size is 1024bits)
-    fn sign(
-        &self,
-        id: &[u8],
-        message: &[u8],
-        recoverable: bool,
-        tx: &TransactionView,
-    ) -> Result<Bytes, SignerError>;
+    fn sign(&self, id: &[u8], message: &[u8], recoverable: bool) -> Result<Bytes, SignerError>;
 }
 
 /// Transaction dependency provider errors

--- a/src/unlock/signer.rs
+++ b/src/unlock/signer.rs
@@ -104,7 +104,7 @@ impl SecpSighashScriptSigner {
         let zero_lock = Bytes::from(vec![0u8; 65]);
         let message = generate_message(&tx_new, script_group, zero_lock)?;
 
-        let signature = self.signer.sign(owner_id, message.as_ref(), true, tx)?;
+        let signature = self.signer.sign(owner_id, message.as_ref(), true)?;
 
         // Put signature into witness
         let witness_data = witnesses[witness_idx].raw_data();
@@ -313,7 +313,7 @@ impl ScriptSigner for SecpMultisigScriptSigner {
             .sighash_addresses
             .iter()
             .filter(|id| self.signer.match_id(id.as_bytes()))
-            .map(|id| self.signer.sign(id.as_bytes(), message.as_ref(), true, tx))
+            .map(|id| self.signer.sign(id.as_bytes(), message.as_ref(), true))
             .collect::<Result<Vec<_>, SignerError>>()?;
         // Put signature into witness
         let witness_idx = script_group.input_indices[0];
@@ -579,7 +579,7 @@ impl OmniLockScriptSigner {
             .sighash_addresses
             .iter()
             .filter(|id| self.signer.match_id(id.as_bytes()))
-            .map(|id| self.signer.sign(id.as_bytes(), message.as_ref(), true, tx))
+            .map(|id| self.signer.sign(id.as_bytes(), message.as_ref(), true))
             .collect::<Result<Vec<_>, SignerError>>()?;
         // Put signature into witness
         let witness_idx = script_group.input_indices[0];
@@ -662,7 +662,7 @@ impl OmniLockScriptSigner {
 
         let signature = self
             .signer
-            .sign(id.auth_content().as_ref(), message.as_ref(), true, tx)?;
+            .sign(id.auth_content().as_ref(), message.as_ref(), true)?;
 
         // Put signature into witness
         let witness_data = witnesses[witness_idx].raw_data();
@@ -783,7 +783,7 @@ impl ScriptSigner for OmniLockScriptSigner {
 
                 let signature =
                     self.signer
-                        .sign(id.auth_content().as_ref(), message.as_ref(), true, tx)?;
+                        .sign(id.auth_content().as_ref(), message.as_ref(), true)?;
 
                 // Put signature into witness
                 let witness_data = witnesses[witness_idx].raw_data();


### PR DESCRIPTION
The `sign` method should be independent of CKB `tx` and should only be concerned with the signing message. Otherwise, it could lead to confusion.

```rust
pub trait Signer {
    /// `message` type is variable length, because different algorithm have
    /// different length of message:
    ///   * secp256k1 => 256bits
    ///   * RSA       => 512bits (when key size is 1024bits)
    fn sign(
        &self,
        id: &[u8],
        message: &[u8],
        recoverable: bool,
        tx: &TransactionView,
    ) -> Result<Bytes, SignerError>;
}
```

remove the `tx` parameter:

```rust
pub trait Signer {
    /// `message` type is variable length, because different algorithm have
    /// different length of message:
    ///   * secp256k1 => 256bits
    ///   * RSA       => 512bits (when key size is 1024bits)
    fn sign(&self, id: &[u8], message: &[u8], recoverable: bool) -> Result<Bytes, SignerError>;
}
```
