### PR TITLE
[BUG Fix] Deadlock issue of InputIterator

### DIFF
--- a/src/transaction/handler/mod.rs
+++ b/src/transaction/handler/mod.rs
@@ -71,7 +71,7 @@ impl HandlerContexts {
         }
     }
 
-    pub fn add_context(mut self, context: Box<dyn HandlerContext>) {
+    pub fn add_context(&mut self, context: Box<dyn HandlerContext>) {
         self.contexts.push(context);
     }
 }

--- a/src/transaction/input/mod.rs
+++ b/src/transaction/input/mod.rs
@@ -1,4 +1,5 @@
 pub mod transaction_input;
+use anyhow::{anyhow, Error};
 use ckb_types::packed::Script;
 pub use transaction_input::TransactionInput;
 
@@ -74,6 +75,10 @@ impl InputIterator {
 
     fn collect_live_cells(&mut self) -> Result<(), CellCollectorError> {
         loop {
+            if self.lock_scripts.len() == 0 {
+                return Ok(());
+            }
+
             if let Some(lock_script) = self.lock_scripts.last() {
                 let mut query = CellQueryOptions::new_lock(lock_script.clone());
                 query.script_search_mode = Some(SearchMode::Exact);


### PR DESCRIPTION
```
 loop {
    if let Some(lock_script) = self.lock_scripts.last() {
        let mut query = CellQueryOptions::new_lock(lock_script.clone());
        query.script_search_mode = Some(SearchMode::Exact);
        if let Some(type_script) = &self.type_script {
            query.secondary_script = Some(type_script.clone());
        } else {
            query.secondary_script_len_range = Some(ValueRangeOption::new_exact(0));
            query.data_len_range = Some(ValueRangeOption::new_exact(0));
        };
        let (live_cells, _capacity) =
            self.cell_collector.collect_live_cells(&query, true)?;
        if live_cells.is_empty() {
            self.lock_scripts.pop();
        } else {
            self.buffer_inputs = live_cells
                .into_iter()
                .rev() // reverse the iter, so that the first cell will be consumed while pop
                .map(|live_cell| TransactionInput::new(live_cell, 0))
                .collect();
            break;
        }
    }
}
```

When `self.lock_scripts` is empty, this loop will dead lock.