### PR TITLE
Add support for customizing local devnet 

### DIFF
--- a/src/transaction/builder/sudt.rs
+++ b/src/transaction/builder/sudt.rs
@@ -29,6 +29,9 @@ pub struct SudtTransactionBuilder {
     input_iter: InputIterator,
     /// The identifier of the sUDT
     sudt_owner_lock_script: Script,
+    /// The sUDT type script, by default we will set default type script for `Mainnet` and `Testnet`
+    /// in the scenario of Dev enviornment, we may need to manually override type script
+    sudt_type_script: Option<Script>,
     /// Whether we are in owner mode
     owner_mode: bool,
     /// The inner transaction builder
@@ -51,6 +54,7 @@ impl SudtTransactionBuilder {
             configuration,
             input_iter,
             sudt_owner_lock_script: sudt_owner_lock_script.into(),
+            sudt_type_script: None,
             owner_mode,
             tx: TransactionBuilder::default(),
         })
@@ -59,6 +63,11 @@ impl SudtTransactionBuilder {
     /// Update the change lock script.
     pub fn set_change_lock(&mut self, lock_script: Script) {
         self.change_lock = lock_script;
+    }
+
+    /// Manually set the sUDT type script
+    pub fn set_sudt_type_script(&mut self, sudt_type_script: Script) {
+        self.sudt_type_script = Some(sudt_type_script);
     }
 
     /// Add an output cell and output data to the transaction.
@@ -72,6 +81,7 @@ impl SudtTransactionBuilder {
         let type_script = build_sudt_type_script(
             self.configuration.network_info(),
             &self.sudt_owner_lock_script,
+            self.sudt_type_script.clone(),
         );
         let output_data = sudt_amount.to_le_bytes().pack();
         let dummy_output = CellOutput::new_builder()
@@ -146,8 +156,10 @@ impl CkbTransactionBuilder for SudtTransactionBuilder {
             configuration,
             mut input_iter,
             sudt_owner_lock_script,
+            sudt_type_script,
             owner_mode,
             mut tx,
+            ..
         } = self;
 
         let change_builder = DefaultChangeBuilder {
@@ -159,8 +171,11 @@ impl CkbTransactionBuilder for SudtTransactionBuilder {
         if owner_mode {
             inner_build(tx, change_builder, input_iter, &configuration, contexts)
         } else {
-            let sudt_type_script =
-                build_sudt_type_script(configuration.network_info(), &sudt_owner_lock_script);
+            let sudt_type_script = build_sudt_type_script(
+                configuration.network_info(),
+                &sudt_owner_lock_script,
+                sudt_type_script,
+            );
             let mut sudt_input_iter = input_iter.clone();
             sudt_input_iter.set_type_script(Some(sudt_type_script));
 
@@ -195,34 +210,14 @@ impl CkbTransactionBuilder for SudtTransactionBuilder {
     }
 }
 
-impl SudtTransactionBuilder {
-    pub fn check(&self) -> Result<(u64, u128), TxBuilderError> {
-        let Self {
-            configuration,
-            input_iter,
-            sudt_owner_lock_script,
-            ..
-        } = self;
-
-        let sudt_type_script =
-            build_sudt_type_script(configuration.network_info(), &sudt_owner_lock_script);
-        let mut sudt_input_iter = input_iter.clone();
-        sudt_input_iter.set_type_script(Some(sudt_type_script));
-
-        let mut udt_sum = 0;
-        let mut ckb_amount: u64 = 0;
-        for input in sudt_input_iter {
-            let input = input?;
-            let capacity: u64 = input.live_cell.output.capacity().unpack();
-            let udt_amount = parse_u128(input.live_cell.output_data.as_ref())?;
-            udt_sum += udt_amount;
-            ckb_amount += capacity;
-        }
-        Ok((ckb_amount, udt_sum))
+fn build_sudt_type_script(
+    network_info: &NetworkInfo,
+    sudt_owner_lock_script: &Script,
+    override_sudt_type_script: Option<Script>,
+) -> Script {
+    if let Some(sudt_type_script) = override_sudt_type_script {
+        return sudt_type_script;
     }
-}
-
-fn build_sudt_type_script(network_info: &NetworkInfo, sudt_owner_lock_script: &Script) -> Script {
     // code_hash from https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0025-simple-udt/0025-simple-udt.md#notes
     let code_hash = match network_info.network_type {
         NetworkType::Mainnet => {
@@ -232,14 +227,7 @@ fn build_sudt_type_script(network_info: &NetworkInfo, sudt_owner_lock_script: &S
             h256!("0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4")
         }
         NetworkType::Dev => {
-            let code_hash =
-                h256!("0xe1e354d6d643ad42724d40967e334984534e0367405c5ae42a9d7d63d77df419");
-            let res = Script::new_builder()
-                .code_hash(code_hash.pack())
-                .hash_type(ScriptHashType::Data1.into())
-                .args(sudt_owner_lock_script.calc_script_hash().as_bytes().pack())
-                .build();
-            return res;
+            panic!("You may need to manually set `sudt_type_script` with `set_sudt_type_script` method");
         }
         _ => panic!("Unsupported network type"),
     };

--- a/src/transaction/handler/multisig.rs
+++ b/src/transaction/handler/multisig.rs
@@ -37,6 +37,9 @@ impl Secp256k1Blake160MultisigAllScriptHandler {
         ret.init(network)?;
         Ok(ret)
     }
+    pub fn new_with_customize(cell_deps: Vec<CellDep>) -> Self {
+        Self { cell_deps }
+    }
 }
 
 impl ScriptHandler for Secp256k1Blake160MultisigAllScriptHandler {

--- a/src/transaction/handler/sighash.rs
+++ b/src/transaction/handler/sighash.rs
@@ -29,6 +29,9 @@ impl Secp256k1Blake160SighashAllScriptHandler {
         ret.init(network)?;
         Ok(ret)
     }
+    pub fn new_with_customize(cell_deps: Vec<CellDep>) -> Self {
+        Self { cell_deps }
+    }
 }
 
 impl ScriptHandler for Secp256k1Blake160SighashAllScriptHandler {

--- a/src/transaction/handler/sudt.rs
+++ b/src/transaction/handler/sudt.rs
@@ -64,6 +64,13 @@ impl SudtHandler {
             sudt_script_id,
         })
     }
+
+    pub fn new_with_customize(cell_deps: Vec<CellDep>, sudt_script_id: ScriptId) -> Self {
+        Self {
+            cell_deps,
+            sudt_script_id,
+        }
+    }
 }
 
 impl ScriptHandler for SudtHandler {

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -29,6 +29,15 @@ impl TransactionBuilderConfiguration {
         Self::new_with_network(NetworkInfo::testnet())
     }
 
+    pub fn new_devnet() -> Result<Self, TxBuilderError> {
+        Ok(Self {
+            network: NetworkInfo::devnet(),
+            script_handlers: vec![],
+            fee_rate: 1000,
+            estimate_tx_size: 128000,
+        })
+    }
+
     pub fn new_with_network(network: NetworkInfo) -> Result<Self, TxBuilderError> {
         let script_handlers = Self::generate_system_handlers(&network)?;
         Ok(Self {

--- a/src/types/network_type.rs
+++ b/src/types/network_type.rs
@@ -88,4 +88,11 @@ impl NetworkInfo {
             url: "https://testnet.ckb.dev".to_string(),
         }
     }
+
+    pub fn devnet() -> Self {
+        Self {
+            network_type: NetworkType::Dev,
+            url: "http://localhost:8114".to_string(),
+        }
+    }
 }


### PR DESCRIPTION
Now the udt-init in fiber are using a branch:
https://github.com/nervosnetwork/fiber/blob/ea415e37a12a9cc3d00494d890248736339c3f49/tests/deploy/udt-init/Cargo.toml#L9

It's better to merge the changes into upstream.
