### PR TITLE
`DefaultCellDepResolver::from_genesis_async` skip fetch genesis_block rpc

### DIFF
--- a/src/traits/default_impls.rs
+++ b/src/traits/default_impls.rs
@@ -189,8 +189,9 @@ impl DefaultCellDepResolver {
                     NetworkInfo::devnet()
                 };
 
-            if let Some((v2_dep_hash, v2_dep_index)) =
-                MultisigScript::V2.dep_group_async(network_info).await
+            if let Some((v2_dep_hash, v2_dep_index)) = MultisigScript::V2
+                .dep_group_async(network_info, Some(genesis_block.to_owned()))
+                .await
             {
                 let multisig_v2_dep = CellDep::new_builder()
                     .out_point(OutPoint::new(v2_dep_hash.pack(), v2_dep_index))

--- a/src/transaction/handler/multisig.rs
+++ b/src/transaction/handler/multisig.rs
@@ -97,13 +97,13 @@ impl ScriptHandler for Secp256k1Blake160MultisigAllScriptHandler {
     #[cfg(not(target_arch = "wasm32"))]
     #[allow(clippy::if_same_then_else)]
     fn init(&mut self, network: &NetworkInfo) -> Result<(), TxBuilderError> {
-        let dep_group =
-            self.multisig_script
-                .dep_group(network.to_owned())
-                .ok_or(TxBuilderError::Other(anyhow!(
-                    "not found multisig dep on network: {:?}",
-                    network
-                )))?;
+        let dep_group = self
+            .multisig_script
+            .dep_group(network.to_owned(), None)
+            .ok_or(TxBuilderError::Other(anyhow!(
+                "not found multisig dep on network: {:?}",
+                network
+            )))?;
         let out_point = OutPoint::new_builder()
             .tx_hash(dep_group.0.pack())
             .index(dep_group.1.pack())
@@ -119,7 +119,7 @@ impl ScriptHandler for Secp256k1Blake160MultisigAllScriptHandler {
     async fn init_async(&mut self, network: &NetworkInfo) -> Result<(), TxBuilderError> {
         let dep_group = self
             .multisig_script
-            .dep_group_async(network.to_owned())
+            .dep_group_async(network.to_owned(), None)
             .await
             .ok_or(TxBuilderError::Other(anyhow!(
                 "not found multisig dep on network: {:?}",


### PR DESCRIPTION
In `DefaultCellDepResolver::from_genesis_async`, pass `genesis_block` to `dep_group_inner`, skip rpc call to fetch genesis_block.