### PR TITLE
Add new_with_cookie for RpcClient

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-2019 ]
+        os: [ ubuntu-latest, macos-latest, windows-2022 ]
     steps:
     - uses: actions/checkout@v2
-    - if: matrix.os == 'windows-2019'
+    - if: matrix.os == 'windows-2022'
       name: Windows Dependencies
       run: |
         iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
@@ -36,10 +36,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-2019 ]
+        os: [ ubuntu-latest, macos-latest, windows-2022 ]
     steps:
     - uses: actions/checkout@v2
-    - if: matrix.os == 'windows-2019'
+    - if: matrix.os == 'windows-2022'
       name: Windows Dependencies
       run: |
         iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.63"
 bech32 = "0.8.1"
 derive-getters = "0.2.1"
 log = "0.4.6"
-reqwest = { version = "0.12", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "cookies"] }
 secp256k1 = { version = "0.30.0", features = ["recovery"] }
 tokio-util = { version = "0.7.7", features = ["codec"] }
 tokio = { version = "1", features = ["time"] }

--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,7 @@ ignore = [
     "RUSTSEC-2024-0370", # proc-macro-error's maintainer seems to be unreachable, ignore this
     "RUSTSEC-2024-0384", # instant is no longer maintained, ignore this
     "RUSTSEC-2024-0436", # paste - no longer maintained
+    "RUSTSEC-2025-0052", # async-std has been discontinued
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
This PR want to add `fn new_with_cookie(uri: &str)` for `RpcClient`

Ref: https://docs.rs/reqwest/0.12.23/reqwest/blocking/struct.ClientBuilder.html#method.cookie_store

@quake 